### PR TITLE
Added tests for config merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.idea/
 # custom ignore-extension
 *.ignore
 *.whl

--- a/ablator/config/main.py
+++ b/ablator/config/main.py
@@ -376,11 +376,13 @@ class ConfigBase:
 
         left_config = self_config
         right_config = copy.deepcopy(config)
+        # updated right_config check instance at the beginning.
+        assert isinstance(right_config, ConfigBase)
         right_annotations = right_config.annotations
-        left_annotations = right_config.annotations
+        # I believe there was a typo here, changed right_config to left_config.
+        left_annotations = left_config.annotations
         left_config.assert_state(right_config)
         right_config.assert_state(left_config)
-        assert isinstance(left_config, type(right_config))
 
         for k in right_annotations:
             assert left_annotations[k] == right_annotations[k]


### PR DESCRIPTION
Implemented Unit test for config merge function in ablator/config/main.py

Updated the merge function implementation, I have mentioned the changed as comments over the code changes. 

I have implemented 3 tests for the merge function:

1. test_merge that checks the functionality of the merge function.
2. test_merge_diff_keys_values, checks if there is a mismatch in the key,value pairs of the left and right configs. 
3. test_merge_diff_class, checks whether the right_config is an instance of the ConfigBase class. 

I chose this function as it would also help in covering tests for other interlinked functions of the config base class like 
assert_state(), diff_str(), diff() and assert_unambiguous() 