### PR TITLE
Added unit test for test_file_logger.py

### DIFF
--- a/tests/modules/test_file_logger.py
+++ b/tests/modules/test_file_logger.py
@@ -29,7 +29,7 @@ def test_file_logger(tmp_path: Path):
     lines = logpath.read_text().split("\n")
     assert len(lines) == 4
     assert lines[0].startswith("Starting Logger")
-    assert lines[1].endswith("hello")
+        assert lines[2].endswith("1 - \x1b[93mhello\x1b[0m")
     
     assert_console_output(lambda: l.error("hello"), lambda s: s.endswith("1 - \x1b[91mhello\x1b[0m\n"))
     lines = logpath.read_text().split("\n")

--- a/tests/modules/test_file_logger.py
+++ b/tests/modules/test_file_logger.py
@@ -5,6 +5,7 @@ from ablator.modules.loggers.tensor import TensorboardLogger
 import sys
 from contextlib import redirect_stdout
 import io
+import os
 
 
 def assert_console_output(fn,assert_fn):
@@ -23,6 +24,18 @@ def test_file_logger(tmp_path: Path):
     assert len(lines) == 3
     assert lines[0].startswith("Starting Logger")
     assert lines[1].endswith("hello")
+    
+    assert_console_output(lambda: l.warn("hello"), lambda s: s.endswith("1 - \x1b[93mhello\x1b[0m\n"))
+    lines = logpath.read_text().split("\n")
+    assert len(lines) == 4
+    assert lines[0].startswith("Starting Logger")
+    assert lines[1].endswith("hello")
+    
+    assert_console_output(lambda: l.error("hello"), lambda s: s.endswith("1 - \x1b[91mhello\x1b[0m\n"))
+    lines = logpath.read_text().split("\n")
+    assert len(lines) == 5
+    assert lines[0].startswith("Starting Logger")
+    assert lines[1].endswith("hello")
 
     l.verbose = False
     assert_console_output(lambda: l.info("hello"), lambda s: len(s) == 0)
@@ -35,7 +48,10 @@ def test_file_logger(tmp_path: Path):
 
 if __name__ == "__main__":
 
-
+    tmp_path = Path("/tmp/")
+    logfile = tmp_path.joinpath("test.log")
+    if os.path.isfile(logfile):
+        os.remove(logfile)
     test_file_logger(Path("/tmp/"))
 
     pass


### PR DESCRIPTION
I chose to write some unit tests for file logger because I encountered a bug when I was exploring the project and got interested in the logger. The log file was not removed before the test run and therefore rerunning the test appends information to the log file and causing the test to fail. I fixed the bug and added additional tests for other two type of  messages (warn, error). This change should help to cover all of the three type of logs for file logger. 