### PR TITLE
Add codecov bot.

### DIFF
--- a/.github/workflows/codecov_report_submit.yml
+++ b/.github/workflows/codecov_report_submit.yml
@@ -1,6 +1,8 @@
 name:  Codecov CI
 
 on:
+  push:
+    branches: [ trainers, abcd, ]
   pull_request:
     branches: [ trainers, abcd, ]
 

--- a/.github/workflows/codecov_report_submit.yml
+++ b/.github/workflows/codecov_report_submit.yml
@@ -1,10 +1,12 @@
-name:  Codecov CI
+name: Codecov CI
 
 on:
   push:
-    branches: [ trainers, abcd, ]
+    branches:
+      - trainers
   pull_request:
-    branches: [ trainers, abcd, ]
+    branches:
+      - trainers
 
 jobs:
   Codecov:
@@ -13,27 +15,27 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda install pip
-        pip install -e .
-        pip install pytest pytest-cov
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an environment variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda install pip
+          pip install -e .
+          pip install pytest pytest-cov
 
-    - name: Run tests
-      run: pytest --cov=./ablator --cov-report=xml
-      continue-on-error: true
+      - name: Run tests
+        run: pytest --cov=./ablator --cov-report=xml
+        continue-on-error: true
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml

--- a/.github/workflows/codecov_report_submit.yml
+++ b/.github/workflows/codecov_report_submit.yml
@@ -1,0 +1,37 @@
+name:  Codecov CI
+
+on:
+  pull_request:
+    branches: [ trainers, abcd, ]
+
+jobs:
+  Codecov:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda install pip
+        pip install -e .
+        pip install pytest pytest-cov
+
+    - name: Run tests
+      run: pytest --cov=./ablator --cov-report=xml
+      continue-on-error: true
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:                  
+  layout: "header,reach,diff,footer"
+  behavior: new
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: no       # [yes :: must have a head report to post]


### PR DESCRIPTION
Add codecov bot to comment on the current code coverage under each pr committed to the `trainers `and `abcd` branches.
### Instruction
1. Register for Codecov:
First, visit [Codecov](https://codecov.io/) and register for a new account. You can register directly with your GitHub account.

2. Import Your Project:
After registration, you will be redirected to your Codecov dashboard. Click on the "Add new repository" button on the left side, then select your GitHub repository to import on the following page.

3. Generate a Codecov Token and Add to GitHub:
If this is your first time importing a project, you will see several instructional steps, you only need to complete the first two (just complete the two steps in the image below)
![image](https://github.com/fostiropoulos/ablator/assets/40203972/80bc2910-90bc-4e6c-b1b1-3a8bae7a4e6c)

### Notes
After the bot is added, it may not immediately display its effect. The bot functions by comparing the base commit of the current PR with the PR itself. When we initially added this bot, we did not incorporate the code coverage report of the trainers or abcd branch code into Codecov. Therefore, the pertinent coverage will not appear here.

However, after this PR is merged into the `trainers` branch, all subsequent branches that are checked out from the trainers branch commit will display the relevant code coverage in the comments under the changed PR. If desired, these comments can be turned off.

It's also important to note that code coverage reports for all commits can be accessed in the Codecov dashboard.