### PR TITLE
fix conflicts between examples and trainers branch

### DIFF
--- a/ablator/main/model/wrapper.py
+++ b/ablator/main/model/wrapper.py
@@ -815,7 +815,8 @@ class ModelWrapper(ModelBase):
         subsample: float
             The fraction of the dataloader to use for validation.
         smoke_test: bool
-            Whether to execute this function as a smoke test. If ``True``, only one iteration will be performed, which is useful for quickly checking if the code runs without errors. Default is ``False``.
+            Whether to execute this function as a smoke test. If ``True``, only one iteration will be performed,
+            which is useful for quickly checking if the code runs without errors. Default is ``False``.
 
         Returns
         -------

--- a/ablator/main/mp.py
+++ b/ablator/main/mp.py
@@ -495,7 +495,8 @@ class ParallelTrainer(ProtoTrainer):
 
         - if available, synchronize Google Cloud storage buckets to working directory defined in runtime configuration.
 
-        - initialize optuna trials and add them to optuna storage and experiment state database for tracking training progress (or retrieve existing trials from optuna storage).
+        - initialize optuna trials and add them to optuna storage
+        and experiment state database for tracking training progress (or retrieve existing trials from optuna storage).
 
         Trials initialized (or retrieved), ``self.experiment_state.running_trials``,
         will be pushed to ray nodes so they can be executed in parallel. After all trials

--- a/ablator/modules/metrics/stores.py
+++ b/ablator/modules/metrics/stores.py
@@ -238,12 +238,14 @@ class PredictionStore:
         **batches : dict[str, np.ndarray]
             A dictionary of key-value pairs, where key is type of prediction (e.g predictions, labels),
             and value is a batch of prediction values. Note that the passed keys in ``**batches`` must match arguments in
-            evaluation functions arguments in the Callable in `evaluation_functions` when we initialize `PredictionStore` object.
+            evaluation functions arguments in the Callable in `evaluation_functions`
+            when we initialize `PredictionStore` object.
 
         Raises
         ------
         AssertionError
-            If passed keys do not match arguments in evaluation functions, or when batches among the keys are different in size.
+            If passed keys do not match arguments in evaluation functions,
+            or when batches among the keys are different in size.
 
         Examples
         --------


### PR DESCRIPTION
Fix all conflicts between `examples ` and `trainers` branch.  those all about the code style conflicts.
