### PR TITLE
update: speed up ci running

### DIFF
--- a/.github/workflows/_linux_test.yml
+++ b/.github/workflows/_linux_test.yml
@@ -13,12 +13,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda install pip
         pip install -e .[dev]
     - name: Install SSH and generate keys
       run: |
@@ -30,5 +26,5 @@ jobs:
         sudo apt-get install -y rsync
     - name: Test with pytest
       run: |
-        conda install pytest
+        pip install pytest
         pytest

--- a/.github/workflows/_linux_test.yml
+++ b/.github/workflows/_linux_test.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install -e .[dev]
+        pip install -e .[dev] -v
     - name: Install SSH and generate keys
       run: |
         sudo apt-get update

--- a/.github/workflows/_mac_test.yml
+++ b/.github/workflows/_mac_test.yml
@@ -27,7 +27,7 @@ jobs:
           cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[dev] -v
       - name: Test with pytest
         run: |
           pip install pytest

--- a/.github/workflows/codecov_report_submit.yml
+++ b/.github/workflows/codecov_report_submit.yml
@@ -19,15 +19,12 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
+          python-version: '3.10'
       - name: Install dependencies
         run: |
-          conda install pip
-          pip install -e .
+          pip install -e .[dev]
+      - name: Install pytest pytest-cov
+        run: |
           pip install pytest pytest-cov
 
       - name: Run tests

--- a/.github/workflows/codecov_report_submit.yml
+++ b/.github/workflows/codecov_report_submit.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[dev] -v
       - name: Install pytest pytest-cov
         run: |
           pip install pytest pytest-cov

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install -e .[dev]
+        pip install -e .[dev] -v
         pip install build
     - name: Build package
       run: python -m build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
@@ -25,10 +17,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        pip install -e .[dev]
         pip install build
     - name: Build package
       run: python -m build

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,25 +10,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.10'
       - name: Install dependencies
         run: |
-          python -m pip install pip==23.0.1
-          pip install .[dev]
+          pip install -e .[dev]
       - name: Run pylint
         run: pylint --fail-under=9 ablator
 
@@ -37,25 +27,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.10'
       - name: Install dependencies
         run: |
-          python -m pip install pip==23.0.1
-          pip install .[dev]
+          pip install -e .[dev]
       - name: Run mypy
         run: mypy ablator
 
@@ -64,25 +44,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: '3.10'
       - name: Install dependencies
         run: |
-          python -m pip install pip==23.0.1
-          pip install .[dev]
+          pip install -e .[dev]
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[dev] -v
       - name: Run pylint
         run: pylint --fail-under=9 ablator
 
@@ -35,7 +35,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[dev] -v
       - name: Run mypy
         run: mypy ablator
 
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -e .[dev]
+          pip install -e .[dev] -v
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
update github action code. 
Before I mix `conda` and `pip` in yml code. This is directly a bad practice. 
And,
I utilized the "install cache" feature of GitHub actions to accelerate the package download. 
However, I found that it actually took up more time during package installation rather than package download.
After realizing that the "install cache" process was quite time-consuming, I made the decision to remove it.
