### PR TITLE
merging type from Rudra-23:rudra-update-public-func-docs

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -55,5 +55,5 @@ jobs:
           pip install -e .[dev] -v
       - name: Lint with flake8
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 ./ablator/ --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 ./ablator/ --count --max-complexity=10 --max-line-length=127 --statistics

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,3 +1,7 @@
 [mypy]
 ignore_missing_imports = True
-plugins=extra/mypy_plugin.py
+plugins=extra/mypy_plugin.py,sqlalchemy.ext.mypy.plugin
+
+[mypy-ray.*]
+follow_imports = skip
+ignore_errors = True

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -72,10 +72,11 @@ You will need to reboot / or log out and log in again for the changes to take ef
 The tests require the latest ABLATOR image to be built. The image must have the same python version as the running environment.
 
 The easiest way to build a docker image is to run the script **with your **development virtual **environment** active** (as it is used to identify the python version you are using):
-`bash script/make_docker.sh`
+`bash scripts/make_docker.sh`
 
 You will **need** to make the docker image in the main ablator directory **every time** before running the tests (as the code in the docker image is updated from the current repository)
 
+**NOTE**  While building the image, you may encounter this error: `Docker-credential-desktop.exe executable file not found in $PATH`. A quick fix is to change `credsStore` to `credStore` in the config file at  `~/.docker/config.json`. ([ref](https://forums.docker.com/t/docker-credential-desktop-exe-executable-file-not-found-in-path-using-wsl2/100225/5))
 ### Details of the Build Process and Docker Instructions (Optional)
 
 You might encounter errors using the script above or you might be working on something that requires you to play around with different python versions. You can inspect [make_docker.sh](scripts/make_docker.sh) or simply play around with:
@@ -234,4 +235,4 @@ docker run -v \
 
 Or simply
 
-`bash scripts/run_test.sh`
+`bash scripts/run_tests.sh`

--- a/ablator/analysis/main.py
+++ b/ablator/analysis/main.py
@@ -55,6 +55,21 @@ class Analysis:
     """
     A class for analyzing experimental results.
 
+    Parameters
+    ----------
+    results : pd.DataFrame | Results
+        The result dataframe.
+    categorical_attributes : list[str] | None
+        The list of all the categorical hyperparameter names
+    numerical_attributes : list[str] | None
+        The list of all the numerical hyperparameter names
+    optim_metrics : dict[str, Optim] | None
+        A dictionary mapping metric names to optimization directions.
+    save_dir : str | None
+        The directory to save analysis results to.
+    cache : bool
+        Whether to cache results.
+
     Attributes
     ----------
     optim_metrics : dict[str, Optim]
@@ -72,6 +87,10 @@ class Analysis:
     results : pd.DataFrame
         The dataframe extracted from the results file based on given metrics names and hyperparameter names.
 
+    Raises
+    ------
+    FileNotFoundError
+        if the provided `save_dir` to save plots don't exists.
     """
 
     def __init__(
@@ -81,26 +100,8 @@ class Analysis:
         numerical_attributes: list[str] | None = None,
         optim_metrics: dict[str, Optim] | None = None,
         save_dir: str | None = None,
-        cache=False,
+        cache: bool = False,
     ) -> None:
-        """
-        Initialize the Analysis class.
-
-        Parameters
-        ----------
-        results : pd.DataFrame | Results
-            The result dataframe.
-        categorical_attributes : list[str] | None, optional
-            The list of all the categorical hyperparameter names, by default ``None``
-        numerical_attributes : list[str] | None, optional
-            The list of all the numerical hyperparameter names, by default ``None``
-        optim_metrics : dict[str, Optim] | None, optional
-            A dictionary mapping metric names to optimization directions, by default ``None``
-        save_dir : str | None, optional
-            The directory to save analysis results to, by default ``None``
-        cache : bool
-            Whether to cache results.
-        """
         (
             df,
             categorical_attributes,
@@ -138,7 +139,24 @@ class Analysis:
         ]
 
     @property
-    def metric_names(self):
+    def metric_names(self) -> list[str]:
+        """
+        Returns
+        -------
+        list[str]
+            list of all the metrics that will be plotted w.r.t hyperparameters.
+
+        Examples
+        --------
+        >>> Make PlotAnalysis's object
+        plots = Analysis(
+            ...
+            optim_metrics={"val_loss": Optim.min, "train_loss": Optim.min},
+        )
+        metrics = plots.metric_names
+        >>> returns
+        ['val_loss', 'train_loss']
+        """
         return list(self.optim_metrics.keys())
 
     @classmethod
@@ -146,7 +164,7 @@ class Analysis:
         cls,
         raw_results: pd.DataFrame,
         metric_map: dict[str, Optim],
-    ):
+    ) -> pd.DataFrame:
         def _best_perf(row: pd.DataFrame, name, obj_fn):
             if Optim(obj_fn) == Optim.min:
                 return row.sort_values(name, na_position="last").iloc[0]
@@ -173,7 +191,7 @@ class Analysis:
         metric_map: dict[str, Optim],
         metric_name_remap: dict[str, str] | None = None,
         attribute_name_remap: dict[str, str] | None = None,
-    ):
+    ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Optim]]:
         """
         Remaps attribute and metric names in ``attributes`` and ``metrics`` DataFrames
         based on ``attribute_name_remap`` and ``metric_name_remap``, and updates ``metric_map``
@@ -181,22 +199,22 @@ class Analysis:
 
         Parameters
         ----------
-        attributes : pandas.DataFrame
+        attributes : pd.DataFrame
             The DataFrame containing attribute values for each experiment.
-        metrics : pandas.DataFrame
+        metrics : pd.DataFrame
             The DataFrame containing metric values for each experiment.
-        metric_map : dict of str to Optim
+        metric_map : dict[str, Optim]
             A dictionary mapping metric names to optimization objectives (minimization or maximization).
-        metric_name_remap : dict of str to str or None, optional
+        metric_name_remap : dict[str, str] | None
             A dictionary mapping input metric names to output metric names.
             If None, the output metric names will be the same as the input metric names.
-        attribute_name_remap : dict of str to str or None, optional
+        attribute_name_remap : dict[str, str] | None
             A dictionary mapping input attribute names to output attribute names.
             If None, the output attribute names will be the same as the input attribute names.
 
         Returns
         -------
-        pandas.DataFrame, pandas.DataFrame, dict of str to Optim
+        tuple[pd.DataFrame, pd.DataFrame, dict[str, Optim]]
             The remapped ``attributes`` DataFrame, the remapped ``metrics`` DataFrame,
             and the updated ``metric_map`` dictionary.
 

--- a/ablator/analysis/plot/__init__.py
+++ b/ablator/analysis/plot/__init__.py
@@ -21,7 +21,7 @@ class Plot(ABC):
         metric_obj_fn: Optim,
         y_axis: str | None = None,
         x_axis: str | None = None,
-        x_ticks: np.ndarray | None = None,
+        x_ticks: list[str] | None = None,
         ax: Axes | None = None,
     ) -> None:
         self.attributes = self._parse_attributes(metric, attributes)

--- a/ablator/analysis/plot/__init__.py
+++ b/ablator/analysis/plot/__init__.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class Plot(ABC):
-    
+
     """
     A base class for parsing experiment results and plotting them with pandas and matplotlib.
 
@@ -30,7 +30,7 @@ class Plot(ABC):
         The y-axis label (metric name), by default None.
     x_axis : str, optional
         The x-axis label (attribute name), by default None.
-    x_ticks : np.ndarray, optional
+    x_ticks : list[str], optional
         The x-axis ticks, by default None.
     ax : Axes, optional
         The axes to plot on, by default None.
@@ -47,7 +47,7 @@ class Plot(ABC):
         The y-axis label (metric name).
     x_axis : str
         The x-axis label (attribute name).
-    x_ticks : np.ndarray
+    x_ticks : list[str]
         The x-axis ticks.
     figure : Figure
         The figure to plot on. If None, new figure of size (4,4) will be created.

--- a/ablator/analysis/plot/__init__.py
+++ b/ablator/analysis/plot/__init__.py
@@ -14,6 +14,47 @@ logger = logging.getLogger(__name__)
 
 
 class Plot(ABC):
+    
+    """
+    A base class for parsing experiment results and plotting them with pandas and matplotlib.
+
+    Parameters
+    ----------
+    metric : pd.Series
+        The ablation study metric values to plot.
+    attributes : pd.Series
+        The ablation study attributes values to plot.
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str, optional
+        The y-axis label (metric name), by default None.
+    x_axis : str, optional
+        The x-axis label (attribute name), by default None.
+    x_ticks : np.ndarray, optional
+        The x-axis ticks, by default None.
+    ax : Axes, optional
+        The axes to plot on, by default None.
+    
+    Attributes
+    ----------
+    metric : pd.Series
+        The ablation study metric values to plot (with null value removed).
+    attributes : pd.Series
+        The ablation study attributes values to plot (with null metric value removed).
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str
+        The y-axis label (metric name).
+    x_axis : str
+        The x-axis label (attribute name).
+    x_ticks : np.ndarray
+        The x-axis ticks.
+    figure : Figure
+        The figure to plot on. If None, new figure of size (4,4) will be created.
+    ax : Axes
+        The axes to plot on. If None, a new axis will be created as the first subplot
+        in the first cell and first column of a 1x1 grid.
+    """
     def __init__(
         self,
         metric: pd.Series,

--- a/ablator/analysis/plot/__init__.py
+++ b/ablator/analysis/plot/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
+import typing as ty
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -46,7 +47,7 @@ class Plot(ABC):
         metric = metric[~metric.isna()]
         return metric
 
-    def _parse_legend(self, ax):
+    def _parse_legend(self, ax: Axes):
         ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.05))
 
     def _parse_figure_axis(
@@ -69,11 +70,11 @@ class Plot(ABC):
 
         ax.figure.tight_layout()
 
-    def make(self, **kwargs):
+    def make(self, **kwargs: ty.Any) -> tuple[Figure, Axes]:
         fig, ax = self._make(**kwargs)
         self._parse_figure_axis(ax, self.x_axis, self.y_axis, self.x_ticks)
         return fig, ax
 
     @abstractmethod
-    def _make(self, **kwargs):
+    def _make(self, **kwargs: ty.Any):
         pass

--- a/ablator/analysis/plot/cat_plot.py
+++ b/ablator/analysis/plot/cat_plot.py
@@ -15,19 +15,54 @@ logger = logging.getLogger(__name__)
 
 
 class Categorical(Plot):
+    # docstring inherited
     """
-    Class for categorical plots
-
-    Attributes
-    ----------
-    DATA_TYPE : str
-        The type of data
-    figsize: tuple
-        A tuple represent size of figure in terms of axes (x, y).
+    This class is for preparing the results that are associated with each categorical attribute to be studied
+    (e.g grouping metric results with each of the attributes). Its constructor takes in as input positional
+    arguments or keyword arguments from the base class `Plot`. Possible arguments are listed in the Parameters
+    section. The Attributes section lists its own attributes as well as those that are inherited.
 
     Parameters
     ----------
-    TODO{hieu} inherit from Plot
+    metric : pd.Series
+        The ablation study metric values to plot.
+    attributes : pd.Series
+        The ablation study attributes values to plot.
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str, optional
+        The y-axis label (metric name), by default `None`.
+    x_axis : str, optional
+        The x-axis label (attribute name), by default `None`.
+    x_ticks : np.ndarray, optional
+        The x-axis ticks, by default `None`.
+    ax : Axes, optional
+        The axes to plot on, by default `None`.
+
+    Attributes
+    ----------
+    metric : pd.Series
+        The ablation study metric values to plot (with null value removed).
+    attributes : pd.Series
+        The ablation study attributes values to plot (with null metric value removed).
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str
+        The y-axis label (metric name).
+    x_axis : str
+        The x-axis label (attribute name).
+    x_ticks : np.ndarray
+        The x-axis ticks.
+    figure : Figure
+        The figure to plot on. If `None`, new figure of size (4,4) will be created.
+    ax : Axes
+        The axes to plot on. If `None`, a new axis will be created as the first subplot
+        in the first cell and first column of a `1x1` grid.
+    DATA_TYPE : str
+        The attribute data type. In this case, it is `"categorical"`.
+    attribute_metric_map : dict[str, pd.Series]
+        A dictionary mapping attribute values to metric values.
+
     """
 
     DATA_TYPE: str = "categorical"
@@ -74,11 +109,53 @@ class Categorical(Plot):
 
 class ViolinPlot(Categorical):
     """
-    Class for constructing violinplots.
+    Class for constructing violinplots. Its constructor takes in as input positional arguments or keyword
+    arguments from the base class `Categorical`. Possible arguments are listed in the Parameters section.
+    The Attributes section lists its own attributes as well as those that are inherited.
 
     Parameters
     ----------
-    TODO{hieu} inherit from Plot
+    metric : pd.Series
+        The ablation study metric values to plot.
+    attributes : pd.Series
+        The ablation study attributes values to plot.
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str, optional
+        The y-axis label (metric name), by default `None`.
+    x_axis : str, optional
+        The x-axis label (attribute name), by default `None`.
+    x_ticks : np.ndarray, optional
+        The x-axis ticks, by default `None`.
+    ax : Axes, optional
+        The axes to plot on, by default `None`.
+
+    Attributes
+    ----------
+    metric : pd.Series
+        The ablation study metric values to plot (with null value removed).
+    attributes : pd.Series
+        The ablation study attributes values to plot (with null metric value removed).
+    metric_obj_fn : Optim
+        The metric optimization direction.
+    y_axis : str
+        The y-axis label (metric name).
+    x_axis : str
+        The x-axis label (attribute name).
+    x_ticks : np.ndarray
+        The x-axis ticks.
+    figure : Figure
+        The figure to plot on. If `None`, new figure of size `(4,4)` will be created.
+    ax : Axes
+        The axes to plot on. If `None`, a new axis will be created as the first subplot
+        in the first cell and first column of a `1x1` grid.
+    DATA_TYPE : str
+        The attribute data type. In this case, it is `"categorical"`.
+    attribute_metric_map : dict[str, pd.Series]
+        A dictionary mapping attribute values to metric values.
+    figsize: tuple
+        A tuple represent size of figure in terms of axes `(x, y)`.
+    
     """
 
     def __init__(self, *args: ty.Any, **kwargs: ty.Any) -> None:

--- a/ablator/analysis/plot/cat_plot.py
+++ b/ablator/analysis/plot/cat_plot.py
@@ -1,4 +1,5 @@
 import logging
+import typing as ty
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,9 +15,24 @@ logger = logging.getLogger(__name__)
 
 
 class Categorical(Plot):
-    DATA_TYPE = "categorical"
+    """
+    Class for categorical plots
 
-    def __init__(self, *args, **kwargs) -> None:
+    Attributes
+    ----------
+    DATA_TYPE : str
+        The type of data
+    figsize: tuple
+        A tuple represent size of figure in terms of axes (x, y).
+
+    Parameters
+    ----------
+    TODO{hieu} inherit from Plot
+    """
+
+    DATA_TYPE: str = "categorical"
+
+    def __init__(self, *args: ty.Any, **kwargs: ty.Any) -> None:
         super().__init__(*args, **kwargs)
         self.attribute_metric_map = self._make_attribute_metric_map(
             self.metric, self.attributes
@@ -27,7 +43,7 @@ class Categorical(Plot):
         cls,
         metric: pd.Series,
         attributes: pd.Series,
-    ):
+    ) -> dict[str, pd.Series]:
         unique_values = attributes.unique()
         metrics: dict[str, pd.Series] = {}
 
@@ -57,7 +73,15 @@ class Categorical(Plot):
 
 
 class ViolinPlot(Categorical):
-    def __init__(self, *args, **kwargs) -> None:
+    """
+    Class for constructing violinplots.
+
+    Parameters
+    ----------
+    TODO{hieu} inherit from Plot
+    """
+
+    def __init__(self, *args: ty.Any, **kwargs: ty.Any) -> None:
         sns.set()
         sns.set_style("whitegrid")
         self.figsize = (8, 4)
@@ -72,8 +96,8 @@ class ViolinPlot(Categorical):
 
     def _make(
         self,
-        **kwargs,
-    ):
+        **kwargs: ty.Any,
+    ) -> tuple[Figure, Axes]:
         sns.violinplot(
             [v.values for v in self.attribute_metric_map.values()],
             ax=self.ax,
@@ -109,5 +133,5 @@ class ViolinPlot(Categorical):
         sns.despine(left=True, bottom=True)
         return self.figure, self.ax
 
-    def _parse_legend(self, ax):
+    def _parse_legend(self, ax: Axes):
         pass

--- a/ablator/analysis/plot/cat_plot.py
+++ b/ablator/analysis/plot/cat_plot.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class Categorical(Plot):
-    # docstring inherited
     """
     This class is for preparing the results that are associated with each categorical attribute to be studied
     (e.g grouping metric results with each of the attributes). Its constructor takes in as input positional
@@ -24,20 +23,24 @@ class Categorical(Plot):
 
     Parameters
     ----------
-    metric : pd.Series
-        The ablation study metric values to plot.
-    attributes : pd.Series
-        The ablation study attributes values to plot.
-    metric_obj_fn : Optim
-        The metric optimization direction.
-    y_axis : str, optional
-        The y-axis label (metric name), by default `None`.
-    x_axis : str, optional
-        The x-axis label (attribute name), by default `None`.
-    x_ticks : np.ndarray, optional
-        The x-axis ticks, by default `None`.
-    ax : Axes, optional
-        The axes to plot on, by default `None`.
+    *args : ty.Any
+        Positional arguments to be passed to the base class `Plot`. These arguments are:
+        ``metric`` : ``pd.Series`` -  The ablation study metric values to plot,
+        ``attributes`` : ``pd.Series`` -  The ablation study attributes values to plot,
+        ``metric_obj_fn`` : ``Optim`` -  The metric optimization direction,
+        ``y_axis`` : ``str, optional`` -  The y-axis label (metric name), by default ``None``,
+        ``x_axis`` : ``str, optional`` -  The x-axis label (attribute name), by default ``None``,
+        ``x_ticks`` : ``list[str], optional`` -  The x-axis ticks, by default ``None``,
+        ``ax`` : ``Axes, optional`` -  The axes to plot on, by default ``None``.
+    **kwargs : ty.Any
+        Keyword arguments to be passed to the base class `Plot`. These arguments are:
+        ``metric`` : ``pd.Series`` -  The ablation study metric values to plot, 
+        ``attributes`` : ``pd.Series`` -  The ablation study attributes values to plot, 
+        ``metric_obj_fn`` : ``Optim`` -  The metric optimization direction, 
+        ``y_axis`` : ``str, optional`` -  The y-axis label (metric name), by default ``None``, 
+        ``x_axis`` : ``str, optional`` -  The x-axis label (attribute name), by default ``None``, 
+        ``x_ticks`` : ``list[str], optional`` -  The x-axis ticks, by default ``None``, 
+        ``ax`` : ``Axes, optional`` -  The axes to plot on, by default ``None``.
 
     Attributes
     ----------
@@ -51,7 +54,7 @@ class Categorical(Plot):
         The y-axis label (metric name).
     x_axis : str
         The x-axis label (attribute name).
-    x_ticks : np.ndarray
+    x_ticks : list[str]
         The x-axis ticks.
     figure : Figure
         The figure to plot on. If `None`, new figure of size (4,4) will be created.
@@ -59,7 +62,7 @@ class Categorical(Plot):
         The axes to plot on. If `None`, a new axis will be created as the first subplot
         in the first cell and first column of a `1x1` grid.
     DATA_TYPE : str
-        The attribute data type. In this case, it is `"categorical"`.
+        The attribute data type. In this case, it is ``"categorical"``.
     attribute_metric_map : dict[str, pd.Series]
         A dictionary mapping attribute values to metric values.
 
@@ -115,20 +118,24 @@ class ViolinPlot(Categorical):
 
     Parameters
     ----------
-    metric : pd.Series
-        The ablation study metric values to plot.
-    attributes : pd.Series
-        The ablation study attributes values to plot.
-    metric_obj_fn : Optim
-        The metric optimization direction.
-    y_axis : str, optional
-        The y-axis label (metric name), by default `None`.
-    x_axis : str, optional
-        The x-axis label (attribute name), by default `None`.
-    x_ticks : np.ndarray, optional
-        The x-axis ticks, by default `None`.
-    ax : Axes, optional
-        The axes to plot on, by default `None`.
+    *args : ty.Any
+        Positional arguments to be passed to the base class `Categorical`. These arguments are:
+        ``metric`` : ``pd.Series`` - The ablation study metric values to plot,
+        ``attributes`` : ``pd.Series`` - The ablation study attributes values to plot,
+        ``metric_obj_fn`` : ``Optim`` - The metric optimization direction,
+        ``y_axis`` : ``str, optional`` - The y-axis label (metric name), by default ``None``,
+        ``x_axis`` : ``str, optional`` - The x-axis label (attribute name), by default ``None``,
+        ``x_ticks`` : ``list[str], optional`` - The x-axis ticks, by default ``None``,
+        ``ax`` : ``Axes, optional`` - The axes to plot on, by default ``None``.
+    **kwargs : ty.Any
+        Keyword arguments to be passed to the base class `Categorical`. These arguments are:
+        ``metric`` : ``pd.Series`` - The ablation study metric values to plot,
+        ``attributes`` : ``pd.Series`` - The ablation study attributes values to plot,
+        ``metric_obj_fn`` : ``Optim`` - The metric optimization direction,
+        ``y_axis`` : ``str, optional`` - The y-axis label (metric name), by default ``None``,
+        ``x_axis`` : ``str, optional`` - The x-axis label (attribute name), by default ``None``,
+        ``x_ticks`` : ``list[str], optional`` - The x-axis ticks, by default ``None``,
+        ``ax`` : ``Axes, optional`` - The axes to plot on, by default ``None``.
 
     Attributes
     ----------
@@ -142,7 +149,7 @@ class ViolinPlot(Categorical):
         The y-axis label (metric name).
     x_axis : str
         The x-axis label (attribute name).
-    x_ticks : np.ndarray
+    x_ticks : list[str]
         The x-axis ticks.
     figure : Figure
         The figure to plot on. If `None`, new figure of size `(4,4)` will be created.
@@ -155,7 +162,7 @@ class ViolinPlot(Categorical):
         A dictionary mapping attribute values to metric values.
     figsize: tuple
         A tuple represent size of figure in terms of axes `(x, y)`.
-    
+
     """
 
     def __init__(self, *args: ty.Any, **kwargs: ty.Any) -> None:

--- a/ablator/analysis/plot/main.py
+++ b/ablator/analysis/plot/main.py
@@ -312,7 +312,9 @@ class PlotAnalysis(Analysis):
         attribute_name_remap : dict[str, str] | None
             mappings for config's searchspace names to user defined names for attributes. By default, None
         **plt_kwargs : ty.Any
-            TODO{hieu}
+            Additional keyword arguments to pass to the plot method. These includes `ax` (`Axes | None` - A matplotlib.axes.Axes
+            object representing the axis to plot on), `append` (A boolean indicating whether to append plots to an
+            existing axes object) and extra arguments for creating the plots.
         """
         cat_attrs = list(self.categorical_attributes)
         num_attrs = list(self.numerical_attributes)

--- a/ablator/analysis/plot/main.py
+++ b/ablator/analysis/plot/main.py
@@ -71,15 +71,15 @@ class PlotAnalysis(Analysis):
         file_format: ty.Literal["png", "pdf", "jpg"] = "png",
     ):
         """
-        Write images to a directory based on fig types,
+        Write images to a directory based on fig types.
 
         Parameters
         ----------
-        fig_map: dict[str, ty.Union[Axes, Figure, Image.Image]]
+        fig_map : dict[str, ty.Union[Axes, Figure, Image.Image]]
             A dictionary mapping names to matplotlib objects.
-        path: Path
+        path : Path
             Path to save the images to.
-        file_format: ty.Literal["png", "pdf", "jpg"]
+        file_format : ty.Literal["png", "pdf", "jpg"]
             the file format to save the images as.
 
         Examples
@@ -106,36 +106,42 @@ class PlotAnalysis(Analysis):
         metrics: pd.DataFrame,
         results: pd.DataFrame,
         metric_map: dict[str, Optim],
-        append=False,
+        append: bool = False,
         ax: Axes | None = None,
         metric_name_remap: dict[str, str] | None = None,
         attribute_name_remap: dict[str, str] | None = None,
         **kwargs,
-    ):
+    ) -> dict:
         """
         Method level docstring goes here.
 
         Parameters
         ----------
-        path: Path | None
+        path : Path | None
             A pathlib.Path object representing the directory to write images to.
-        plot_cls: type[Plot]
+        plot_cls : type[Plot]
             A subclass of Plot representing the type of plot to make.
-        metrics: pd.DataFrame
+        metrics : pd.DataFrame
             A pandas DataFrame containing metric values.
-        results: pd.DataFrame
+        results : pd.DataFrame
             A pandas DataFrame containing attribute values.
-        metric_map: dict[str, Optim]
+        metric_map : dict[str, Optim]
             A dictionary mapping metric names to optimization functions.
-        append: bool
+        append : bool
             A boolean indicating whether to append plots to an existing axes object.
-        ax: Axes | None
+        ax : Axes | None
             A matplotlib.axes.Axes object representing the axis to plot on.
-        metric_name_remap: dict[str, str] | None
+        metric_name_remap : dict[str, str] | None
             An optional dictionary mapping metric names to new metric names.
-        attribute_name_remap: dict[str, str] | None
+        attribute_name_remap : dict[str, str] | None
             An optional dictionary mapping attribute names to new attribute names.
-        kwargs: Additional keyword arguments to pass to the plot method.
+        **kwargs
+            Additional keyword arguments to pass to the plot method.
+
+        Returns
+        -------
+        dict
+            A dictionary of metric name to its axes_map
 
         Examples
         --------
@@ -225,6 +231,21 @@ class PlotAnalysis(Analysis):
         save_dir: ty.Union[Path, str],
         **plt_kwargs,
     ):
+        """
+        To make violinplots for the given attribute names (data type: discrete) v.s. the metrics
+        and saving the plots to the `save_dir` directory.
+
+        Parameters
+        ----------
+        attribute_names : list[str]
+            list of attributes to plot against the metrics.
+        metrics : list[str]
+            list of metrics to plot against the given attributes.
+        save_dir : ty.Union[Path, str]
+            directory to save results.
+        **plt_kwargs
+            Additional keyword arguments to pass to the plot.
+        """
         save_path = Path(save_dir).joinpath("violinplot")
         metric_map = {k: v for k, v in self.optim_metrics.items() if k in metrics}
         self._make_metric_plots(
@@ -242,7 +263,26 @@ class PlotAnalysis(Analysis):
         metrics: list[str],
         save_dir: ty.Union[Path, str],
         **plt_kwargs,
-    ):
+    ) -> dict:
+        """
+        To make linear plots for the given attribute names (data type: numerical) v.s. the metrics
+          and saving the plots to the `save_dir` directory.
+
+        Parameters
+        ----------
+        attribute_names : list[str]
+            list of attributes to plot against the metrics.
+        metrics : list[str]
+            list of metrics to plot against the given attributes.
+        save_dir : ty.Union[Path, str]
+            directory to save results.
+        **plt_kwargs
+            Additional keyword arguments to pass to the plot method.
+
+        Returns
+        -------
+        dict
+        """
         save_path = Path(save_dir).joinpath("linearplot")
         metric_map = {k: v for k, v in self.optim_metrics.items() if k in metrics}
 
@@ -259,8 +299,21 @@ class PlotAnalysis(Analysis):
         self,
         metric_name_remap: dict[str, str] | None = None,
         attribute_name_remap: dict[str, str] | None = None,
-        **plt_kwargs,
+        **plt_kwargs: ty.Any,
     ):
+        """
+        The function to generate violinplots for categorical values and linear plots for numerical values.
+        Plots are created as metrics vs. attributes.
+
+        Parameters
+        ----------
+        metric_name_remap : dict[str, str] | None
+            mappings for config's metrics keys to user defined names. By default, None
+        attribute_name_remap : dict[str, str] | None
+            mappings for config's searchspace names to user defined names for attributes. By default, None
+        **plt_kwargs : ty.Any
+            TODO{hieu}
+        """
         cat_attrs = list(self.categorical_attributes)
         num_attrs = list(self.numerical_attributes)
         if attribute_name_remap is not None:

--- a/ablator/analysis/plot/num_plot.py
+++ b/ablator/analysis/plot/num_plot.py
@@ -11,10 +11,31 @@ logger = logging.getLogger(__name__)
 
 
 class Numerical(Plot):
-    DATA_TYPE = "numerical"
+    """
+    Base class for numerical plots
+
+    Attributes
+    ----------
+    DATA_TYPE: str
+        data_type for numerical plots.
+
+    """
+
+    DATA_TYPE: str = "numerical"
 
 
 class LinearPlot(Numerical):
+    """
+    Class for generating linear plots
+
+    Parameters
+    ----------
+    ax: Axes
+        axes object of linear plot.
+    figure: Figure
+        Its corresponding figure object.
+    """
+
     def _make(
         self,
         scatter_plot: bool = True,
@@ -42,5 +63,5 @@ class LinearPlot(Numerical):
 
         return self.figure, self.ax
 
-    def _parse_legend(self, ax):
+    def _parse_legend(self, ax: Axes):
         pass

--- a/ablator/analysis/plot/utils.py
+++ b/ablator/analysis/plot/utils.py
@@ -13,16 +13,16 @@ def parse_name_remap(
 
     Parameters
     ----------
-    defaults : list of str or None, optional
+    defaults : list[str] | None
         The default attribute names to use as keys in the output dictionary.
         If ``None``, the output dictionary will be based on ``name_map`` only.
-    name_map : dict of str to str or None, optional
+    name_map : dict[str, str] | None
         A dictionary mapping input attribute names to output attribute names.
         If ``None``, the output dictionary will be based on ``defaults`` only.
 
     Returns
     -------
-    dict of str to str
+    dict[str, str]
         A dictionary mapping input attribute names to output attribute names.
 
     Raises

--- a/ablator/analysis/results.py
+++ b/ablator/analysis/results.py
@@ -184,7 +184,7 @@ class Results:
             raise FileNotFoundError(f"{run_config_path}")
         self.config = config_type.load(run_config_path)
         # TODO we need to have mypy plugin to interpret Dict[Optim] as dict[str, Optim]
-        self.metric_map: dict[str, Optim] = self.config.optim_metrics  # type: ignore
+        self.metric_map: dict[str, Optim] = self.config.optim_metrics # type: ignore[assignment]
         self.data: pd.DataFrame = self._make_data(use_ray=use_ray, clean=not cache)
 
         self.config_attrs: list[str] = list(self.config.search_space.keys())
@@ -237,7 +237,7 @@ class Results:
                 )
 
     @property
-    def metric_names(self) -> list[str]:  # type: ignore
+    def metric_names(self) -> list[str]:
         """
         Get the list of all optimize directions
 

--- a/ablator/config/hpo.py
+++ b/ablator/config/hpo.py
@@ -117,7 +117,7 @@ class SearchSpace(ConfigBase):
         value type of the parameter's values (continous or discrete).
     n_bins: Optional[int]
         Total bins for grid sampling, optional
-    log: bool = False
+    log: bool
         To log. by default, False.
 
     Examples

--- a/ablator/config/hpo.py
+++ b/ablator/config/hpo.py
@@ -7,7 +7,7 @@ from ablator.config.types import Annotation, Enum, List, Optional, Self, Tuple, 
 
 class SubConfiguration:
     """
-    SubConfiguration for a searchSpace.
+    SubConfiguration for a SearchSpace.
 
     Attributes
     ----------
@@ -16,7 +16,41 @@ class SubConfiguration:
 
     Parameters
     ----------
-    TODO{hiue}
+    kwargs: ty.Any
+        Keyword arguments for the subconfigurations, can be nested dictionary of search spaces.
+    
+    Examples
+    --------
+    >>> search_space = {
+    ...     "train_config.optimizer_config": SearchSpace(
+    ...         subspaces=[
+    ...             {"sub_configuration": {"name": "sgd", "arguments": {"lr": 0.1}}},
+    ...             {
+    ...                 "sub_configuration": {
+    ...                     "name": "adam",
+    ...                     "arguments": {
+    ...                         "lr": {"value_range": (0, 1), "value_type": "float"},
+    ...                         "weight_decay": 0.9,
+    ...                     },
+    ...                 }
+    ...             },
+    ...             {
+    ...                 "sub_configuration": {
+    ...                     "name": "adam",
+    ...                     "arguments": {
+    ...                         "lr": {
+    ...                             "subspaces": [
+    ...                                 {"value_range": (0, 1), "value_type": "float"},
+    ...                                 {"value_range": (0, 1), "value_type": "float"},
+    ...                             ]
+    ...                         },
+    ...                         "weight_decay": 0.9,
+    ...                     },
+    ...                 }
+    ...             },
+    ...         ]
+    ...     )
+    ... }
 
     """
 
@@ -97,12 +131,28 @@ class FieldType(Enum):
 @configclass
 class SearchSpace(ConfigBase):
     """
-    Search space configuration, required in ``ParallelConfig``, is used to define
-    the search space for a hyperparameter.
+    Search space configuration, required in ``ParallelConfig``, is used to define the
+    search space for a hyperparameter. Its constructor takes in as input positional
+    arguments or keyword arguments that corresponds to parameters defined in the
+    Parameters section.
 
     Parameters
     ----------
-    TODO{hieu}
+    value_range: Optional[Tuple[str, str]]
+        value range of the parameter.
+    categorical_values: Optional[List[str]]
+        categorical values for the parameter.
+    subspaces: Optional[List[Self]]
+        Nested SearchSpace, optional
+    sub_configuration: Optional[SubConfiguration]
+        SubConfiguration for a SearchSpace, optional
+    value_type: FieldType = FieldType.continuous
+        value type of the parameter's values (continous or discrete).
+    n_bins: Optional[int]
+        Total bins for grid sampling, optional
+    log: bool = False
+        To log. by default, False.
+    
 
     Attributes
     ----------
@@ -113,6 +163,7 @@ class SearchSpace(ConfigBase):
     subspaces: Optional[List[Self]]
         Nested SearchSpace, optional
     sub_configuration: Optional[SubConfiguration]
+        SubConfiguration for a SearchSpace, optional
     value_type: FieldType = FieldType.continuous
         value type of the parameter's values (continous or discrete).
     n_bins: Optional[int]

--- a/ablator/config/hpo.py
+++ b/ablator/config/hpo.py
@@ -16,7 +16,7 @@ class SubConfiguration:
 
     Parameters
     ----------
-    kwargs: ty.Any
+    **kwargs: ty.Any
         Keyword arguments for the subconfigurations, can be nested dictionary of search spaces.
     
     Examples
@@ -138,20 +138,24 @@ class SearchSpace(ConfigBase):
 
     Parameters
     ----------
-    value_range: Optional[Tuple[str, str]]
-        value range of the parameter.
-    categorical_values: Optional[List[str]]
-        categorical values for the parameter.
-    subspaces: Optional[List[Self]]
-        Nested SearchSpace, optional
-    sub_configuration: Optional[SubConfiguration]
-        SubConfiguration for a SearchSpace, optional
-    value_type: FieldType = FieldType.continuous
-        value type of the parameter's values (continous or discrete).
-    n_bins: Optional[int]
-        Total bins for grid sampling, optional
-    log: bool = False
-        To log. by default, False.
+    *args : ty.Any
+        Positional arguments to be passed. These arguments are:
+        ``value_range``: ``Optional[Tuple[str, str]]`` - value range of the parameter,
+        ``categorical_values``: ``Optional[List[str]]`` - categorical values for the parameter,
+        ``subspaces``: ``Optional[List[Self]]`` - Nested SearchSpace, optional,
+        ``sub_configuration``: ``Optional[SubConfiguration]`` - SubConfiguration for a SearchSpace, optional,
+        ``value_type``: ``FieldType`` - value type of the parameter's values (continous or discrete). By default, ``FieldType.continuous``,
+        ``n_bins``: ``Optional[int]`` - Total bins for grid sampling, optional,
+        ``log``: ``bool`` - To log. By default, ``False``.
+    **kwargs : ty.Any
+        Keyword arguments to be passed. These arguments are:
+        ``value_range``: ``Optional[Tuple[str, str]]`` - value range of the parameter,
+        ``categorical_values``: ``Optional[List[str]]`` - categorical values for the parameter,
+        ``subspaces``: ``Optional[List[Self]]`` - Nested SearchSpace, optional,
+        ``sub_configuration``: ``Optional[SubConfiguration]`` - SubConfiguration for a SearchSpace, optional,
+        ``value_type``: ``FieldType`` - value type of the parameter's values (continous or discrete). By default, ``FieldType.continuous``,
+        ``n_bins``: ``Optional[int]`` - Total bins for grid sampling, optional,
+        ``log``: ``bool`` - To log. By default, ``False``.
     
 
     Attributes

--- a/ablator/config/main.py
+++ b/ablator/config/main.py
@@ -192,6 +192,7 @@ class ConfigBase:
                 unspected_args,
             )
 
+    def _validate_inputs(self, *args, debug: bool, **kwargs) -> list[str]:
         added_variables = {
             item[0]
             for item in inspect.getmembers(type(self))

--- a/ablator/config/main.py
+++ b/ablator/config/main.py
@@ -28,24 +28,24 @@ from ablator.config.types import (
 from ablator.config.utils import dict_hash, flatten_nested_dict, parse_repr_to_kwargs
 
 
-def configclass(cls: ty.Type["ConfigBase"]) -> ty.Type["ConfigBase"]:
+def configclass(cls: type["ConfigBase"]) -> type["ConfigBase"]:
     """
     Decorator for ConfigBase subclasses, adds the ``config_class`` attribute to the class.
 
     Parameters
     ----------
-    cls : ty.Type["ConfigBase"]
+    cls : type["ConfigBase"]
         The class to be decorated.
 
     Returns
     -------
-    ty.Type[ConfigBase]
+    type[ConfigBase]
         The decorated class with the ``config_class`` attribute.
     """
 
     assert issubclass(cls, ConfigBase), f"{cls.__name__} must inherit from ConfigBase"
     setattr(cls, "config_class", cls)
-    return dataclass(cls, init=False, repr=False, kw_only=True, eq=False)
+    return dataclass(cls, init=False, repr=False, kw_only=True, eq=False)  # type: ignore[call-overload]
 
 
 def _freeze_helper(obj):
@@ -216,7 +216,7 @@ class ConfigBase:
             raise ValueError(
                 f"{self._class_name} does not support positional arguments."
             )
-        if not isinstance(self, self.config_class):  # type: ignore[arg-type]
+        if not isinstance(self, self.config_class): # type: ignore[arg-type]
             raise RuntimeError(
                 f"You must decorate your Config class '{self._class_name}' with ablator.configclass."
             )
@@ -306,7 +306,10 @@ class ConfigBase:
         Self
             The loaded configuration object.
         """
-        kwargs: dict = OmegaConf.to_object(OmegaConf.create(Path(path).read_text(encoding="utf-8")))  # type: ignore
+        # TODO[iordanis] remove OmegaConf dependency
+        kwargs: dict = OmegaConf.to_object( # type: ignore[assignment]
+            OmegaConf.create(Path(path).read_text(encoding="utf-8"))
+        )
         return cls(**kwargs, debug=debug)
 
     @property

--- a/ablator/config/main.py
+++ b/ablator/config/main.py
@@ -1,9 +1,10 @@
+from collections import abc
 import copy
 import inspect
 import logging
 import operator
 import typing as ty
-from typing import Any, Union, KeysView
+from typing import Any, Union
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -100,10 +101,11 @@ class ConfigBase:
     This class is the building block for all configuration objects within ablator. It serves as the base class for
     configurations such as ``ModelConfig``, ``TrainConfig``, ``OptimizerConfig``, and more.
 
-    To customize configurations for specific needs, you can create your own configuration class by inheriting from ``ConfigBase``.
-    It's essential to annotate it with ``@configclass``. For instance, in the tutorial `Search space for
-    different types of optimizers and scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_, a custom optimizer config class is created to enable ablation study on various optimizers
-    and schedulers. You can refer to this tutorial for an example of how to create your custom configuration class.
+    To customize configurations for specific needs, you can create your own configuration class by
+    inheriting from ``ConfigBase``. It's essential to annotate it with ``@configclass``. For instance, in the tutorial
+    `Search space for different types of optimizers and scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_,
+    a custom optimizer config class is created to enable ablation study on various optimizers and schedulers.
+    You can refer to this tutorial for an example of how to create your custom configuration class.
 
     Examples
     --------
@@ -140,7 +142,7 @@ class ConfigBase:
        All config class must be decorated with ``@configclass``.
 
     """
-    config_class: Type = type(None)
+    config_class = type(None)
 
     def __init__(self, *args: Any, debug: bool = False, **kwargs: Any):
         self._debug: bool
@@ -276,7 +278,7 @@ class ConfigBase:
             + ")"
         )
 
-    def keys(self) -> KeysView[str]:
+    def keys(self) -> abc.KeysView[str]:
         """
         Get the keys of the configuration dictionary.
 

--- a/ablator/config/main.py
+++ b/ablator/config/main.py
@@ -28,18 +28,18 @@ from ablator.config.types import (
 from ablator.config.utils import dict_hash, flatten_nested_dict, parse_repr_to_kwargs
 
 
-def configclass(cls):  # noqa
+def configclass(cls: ty.Type["ConfigBase"]) -> ty.Type["ConfigBase"]:
     """
     Decorator for ConfigBase subclasses, adds the ``config_class`` attribute to the class.
 
     Parameters
     ----------
-    cls : Type[ConfigBase]
+    cls : ty.Type["ConfigBase"]
         The class to be decorated.
 
     Returns
     -------
-    Type[ConfigBase]
+    ty.Type[ConfigBase]
         The decorated class with the ``config_class`` attribute.
     """
 
@@ -119,8 +119,8 @@ class ConfigBase:
     ----------
     *args : Any
         Positional arguments.
-    debug : bool, optional, default=False
-        Whether to load the configuration in debug mode, and ignore discrepancies / errors.
+    debug : bool, optional
+        Whether to load the configuration in debug mode, and ignore discrepancies/errors, by default ``False``
     **kwargs : Any
         Keyword arguments.
 
@@ -284,7 +284,7 @@ class ConfigBase:
 
         Returns
         -------
-        KeysView[str]
+        abc.KeysView[str]
             The keys of the configuration dictionary.
         """
         return self.to_dict().keys()
@@ -299,7 +299,7 @@ class ConfigBase:
         path : Union[Path, str]
             The path to the configuration file.
         debug : bool, optional, default=False
-            Whether to load the configuration in debug mode, and ignore discrepencies / errors.
+            Whether to load the configuration in debug mode, and ignore discrepancies/errors.
 
         Returns
         -------
@@ -397,7 +397,6 @@ class ConfigBase:
         return annot[element].variable_type
 
     # pylint: disable=too-complex
-    # flake8: noqa: C901
     def make_dict(
         self,
         annotations: dict[str, Annotation],

--- a/ablator/config/mp.py
+++ b/ablator/config/mp.py
@@ -87,9 +87,13 @@ class ParallelConfig(RunConfig):
     - Define search space:
 
     >>> search_space = {
-    ...     "train_config.optimizer_config.arguments.lr": SearchSpace(value_range = [0.001, 0.01], value_type = 'float'),
-    ...     "model_config.hidden_size": SearchSpace(value_range = [32, 64], value_type = 'int'),
-    ...     "model_config.activation": SearchSpace(categorical_values = ["relu", "elu", "leakyRelu"]),
+    ...     "train_config.optimizer_config.arguments.lr": SearchSpace(
+    ...         value_range=[0.001, 0.01], value_type="float"
+    ...     ),
+    ...     "model_config.hidden_size": SearchSpace(value_range=[32, 64], value_type="int"),
+    ...     "model_config.activation": SearchSpace(
+    ...         categorical_values=["relu", "elu", "leakyRelu"]
+    ...     ),
     ... }
 
     - Lastly, we will define the run config from the previous config components (remember to redefine

--- a/ablator/config/proto.py
+++ b/ablator/config/proto.py
@@ -35,8 +35,6 @@ class TrainConfig(ConfigBase):
         optimizer configuration. (check ``OptimizerConfig`` for more details)
     scheduler_config: Optional[SchedulerConfig]
         scheduler configuration. (check ``SchedulerConfig`` for more details)
-    rand_weights_init: bool = True
-        whether to initialize model weights randomly.
 
     Examples
     --------
@@ -60,8 +58,7 @@ class TrainConfig(ConfigBase):
     ...     batch_size=32,
     ...     epochs=10,
     ...     optimizer_config = my_optimizer_config,
-    ...     scheduler_config = my_scheduler_config,
-    ...     rand_weights_init = True
+    ...     scheduler_config = my_scheduler_config
     ... )
 
     - We now define the run config for prototype training, which is the last configuration step.
@@ -187,8 +184,7 @@ class RunConfig(ConfigBase):
     ...     batch_size=32,
     ...     epochs=10,
     ...     optimizer_config = my_optimizer_config,
-    ...     scheduler_config = my_scheduler_config,
-    ...     rand_weights_init = True
+    ...     scheduler_config = my_scheduler_config
     ... )
 
     - Define model config, here we use default one with no custom hyperparameters (sometimes you would

--- a/ablator/config/proto.py
+++ b/ablator/config/proto.py
@@ -64,9 +64,9 @@ class TrainConfig(ConfigBase):
     ...     rand_weights_init = True
     ... )
 
-    - We now define the run config for prototype training, which is the last configuration step. Refer to :ref:`Configurations
-      for single model experiments <run_config>` and :ref:`Configurations for parallel models experiments <parallel_config>`
-      for more details on running configs.
+    - We now define the run config for prototype training, which is the last configuration step.
+    Refer to :ref:`Configurations for single model experiments <run_config>` and
+    :ref:`Configurations for parallel models experiments <parallel_config>` for more details on running configs.
 
     >>> run_config = CustomRunConfig(
     ...     train_config=my_train_config,

--- a/ablator/config/types.py
+++ b/ablator/config/types.py
@@ -4,6 +4,7 @@ Custom types for runtime checking
 
 import typing as ty
 import inspect
+from typing import Any
 from collections import namedtuple
 from enum import Enum as _Enum
 
@@ -228,7 +229,7 @@ class Enum(_Enum):
             val = type(self)(val)
         return super().__eq__(val)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Calculates the hash of the Enum instance.
 
@@ -317,13 +318,13 @@ def _val2bool(val: str | bool) -> bool:
     raise ValueError(f"Cannot parse {val} as bool.")
 
 
-def _strip_hint_state(type_hint):
+def _strip_hint_state(type_hint: type[Any]) -> tuple:
     """
     Strips the hint state from a type hint.
 
     Parameters
     ----------
-    type_hint : Type
+    type_hint : type[Any]
         The input type hint to strip the state from.
 
     Returns
@@ -346,13 +347,13 @@ def _strip_hint_state(type_hint):
     return Stateful, type_hint
 
 
-def _strip_hint_optional(type_hint):
+def _strip_hint_optional(type_hint: type[Any]) -> tuple:
     """
     Strips the optional part of a type hint.
 
     Parameters
     ----------
-    type_hint : Type
+    type_hint : type[Any]
         The input type hint to strip the optional part from.
 
     Returns
@@ -372,13 +373,13 @@ def _strip_hint_optional(type_hint):
     return False, type_hint
 
 
-def _strip_hint_collection(type_hint):
+def _strip_hint_collection(type_hint: type[Any]) -> tuple:
     """
     Strips the collection from a type hint.
 
     Parameters
     ----------
-    type_hint : Type
+    type_hint : type[Any]
         The input type hint to strip the collection from.
 
     Returns
@@ -426,7 +427,7 @@ def _strip_hint_collection(type_hint):
     )
 
 
-def parse_type_hint(cls, type_hint):
+def parse_type_hint(cls: Any, type_hint: type[Any]) -> Annotation:
     """
     Parses a type hint and returns a parsed annotation.
 
@@ -434,7 +435,7 @@ def parse_type_hint(cls, type_hint):
     ----------
     cls : Any
         The class being annotated.
-    type_hint : Type
+    type_hint : type[Any]
         The input type hint to parse.
 
     Returns
@@ -462,19 +463,19 @@ def parse_type_hint(cls, type_hint):
     )
 
 
-def _parse_class(cls, args_kwargs, debug: bool = False):
+def _parse_class(cls: Any, kwargs: dict | object, debug: bool = False) -> object:
     """
     Parse values whose types are not  a collection or in ALLOWED_TYPES
     eg. bool, added dict(tune configs)
 
     Parameters
     ----------
-    cls : Type
+    cls : Any
         The input Type
-    args_kwargs : dict or object
-        The keyword arguments or object to parse with the given type
+    args_kwargs : dict | object
+        The positional and keyword arguments or object to parse with the given type
     debug : bool, optional, default=False
-        Whether to load the configuration in debug mode, and ignore discrepancies / errors.
+        Whether to load the configuration in debug mode, and ignore discrepancies/errors.
 
     Returns
     -------
@@ -519,8 +520,10 @@ def _parse_class(cls, args_kwargs, debug: bool = False):
     return cls(*args, **kwargs)
 
 
-# pylint: disable=too-complex
-def parse_value(val, annot: Annotation, name=None, debug: bool = False):
+# flake8: noqa: C901
+def parse_value(
+    val: Any, annot: Annotation, name: str | None = None, debug: bool = False
+) -> ty.Any:
     """
     Parses a value based on the given annotation.
 
@@ -530,14 +533,14 @@ def parse_value(val, annot: Annotation, name=None, debug: bool = False):
         The input value to parse.
     annot : Annotation
         The annotation namedtuple to guide the parsing.
-    name : str, optional
+    name : str | None
         The name of the value, by default ``None``.
     debug : bool, optional, default=False
         Whether to load the configuration in debug mode, and ignore discrepencies / errors.
 
     Returns
     -------
-    Any
+    ty.Any
         The parsed value.
 
     Raises

--- a/ablator/config/types.py
+++ b/ablator/config/types.py
@@ -463,7 +463,7 @@ def parse_type_hint(cls: Any, type_hint: type[Any]) -> Annotation:
     )
 
 
-def _parse_class(cls: Any, kwargs: dict | object, debug: bool = False) -> object:
+def _parse_class(cls: Any, args_kwargs: dict | object, debug: bool = False) -> object:
     """
     Parse values whose types are not  a collection or in ALLOWED_TYPES
     eg. bool, added dict(tune configs)

--- a/ablator/config/types.py
+++ b/ablator/config/types.py
@@ -58,8 +58,6 @@ class Dict(ty.Dict[str, T]):
 
     """
 
-    pass
-
 
 # pylint: disable=deprecated-typing-alias
 class List(ty.List[T]):
@@ -96,8 +94,6 @@ class List(ty.List[T]):
     and the value of ``my_int_list[2]`` is cast to an integer.
 
     """
-
-    pass
 
 
 # pylint: disable=deprecated-typing-alias
@@ -136,8 +132,6 @@ class Tuple(ty.Tuple[T]):
         ``my_2str_int_tuple`` must have exactly 3 elements.
     """
 
-    pass
-
 
 class Optional(ty.Generic[T]):
     """
@@ -163,12 +157,10 @@ class Optional(ty.Generic[T]):
     my_optional_list: null
     """
 
-    pass
-
 
 # Support for nested objects
 class Self:
-    pass
+    ...
 
 
 Type = type
@@ -521,6 +513,7 @@ def _parse_class(cls: Any, args_kwargs: dict | object, debug: bool = False) -> o
 
 
 # flake8: noqa: C901
+# pylint: disable=too-complex
 def parse_value(
     val: Any, annot: Annotation, name: str | None = None, debug: bool = False
 ) -> ty.Any:
@@ -623,8 +616,8 @@ class Stateful(ty.Generic[T]):
 
     Examples
     --------
-    The below example defines a model config that has stateful embedding dimensions, which means among every experiment,
-    the embedding dimension must be the same (and will be 100).
+    The below example defines a model config that has stateful embedding dimensions, which means that in
+    every experiment, the embedding dimension must be the same (and will be 100).
 
     >>> @configclass
     >>> class MyModelConfig(ModelConfig):
@@ -632,11 +625,11 @@ class Stateful(ty.Generic[T]):
     >>> model_config = MyModelConfig(embed_dim=100) # Must provide values for ``embed_dim`` before launching experiment
 
     .. note::
-        - In contrary to ``Derived``, when initializing config objects (aka before launching the experiment), you have to
-          assign values to their stateful attributes.
-        - Stateful is only applied in the context of experiments. So a stateful attribute must be the same between different
-          run of the same experiment configurations. However, within each experiment, a search space on stateful attributes
-          can be defined to run HPO on them.
+        - In contrary to ``Derived``, when initializing config objects (aka before launching the experiment),
+        you have to assign values to their stateful attributes.
+        - Stateful is only applied in the context of experiments. So a stateful attribute must be
+        the same between different run of the same experiment configurations. However, within each experiment,
+        a search space on stateful attributes can be defined to run HPO on them.
 
     """
 
@@ -644,16 +637,16 @@ class Stateful(ty.Generic[T]):
 class Derived(ty.Generic[T]):
     """
     This type is for attributes that are derived during the experiment (after launching the experiment).
-    To make an attribute derived, wrap ``Derived`` around its type defenition, e.g ``Derived[List[int]]``,
+    To make an attribute derived, wrap ``Derived`` around its type definition, e.g ``Derived[List[int]]``,
     ``Derived[str]``.
 
     Examples
     --------
     For example, you want to test how different pretrained word embeddings (e.g word2vec 100d, word2vec 300d) affect the
-    performance of a classification model, and you will use ablator to run ablation study on the effect of word embeddings.
-    Plus, the classification model architecture depends on the size of the embedding length of each pretrained set of word
-    embeddings. In this case, the model architecture is derived from the pretrained word embeddings. So you can define a model
-    config class as follows:
+    performance of a classification model, and you will use ablator to run ablation study on
+    the effect of word embeddings. Plus, the classification model architecture depends on the size
+    of the embedding length of each pretrained set of word embeddings. In this case, the model architecture
+    is derived from the pretrained word embeddings. So you can define a model config class as follows:
 
     >>> @configclass
     >>> class MyModelConfig(ModelConfig):
@@ -666,7 +659,8 @@ class Derived(ty.Generic[T]):
     >>>         super().__init__()
     >>>         self.embed_dim = config.embed_dim
 
-    Finally, ``config_parser`` is used to set the value of Derived attribute ``embed_dim`` based on the pretrained word embeddings:
+    Finally, ``config_parser`` is used to set the value of Derived attribute ``embed_dim``
+    based on the pretrained word embeddings:
 
     >>> class MyLMWrapper(ModelWrapper):
     >>>     def config_parser(self, run_config: RunConfig):
@@ -682,7 +676,7 @@ class Derived(ty.Generic[T]):
 class Stateless(ty.Generic[T]):
     """
     This type is for attributes that can take different value assignments between experiments. To make an
-    attribute stateless, wrap ``Stateless`` around its type defenition, e.g ``Stateless[List[int]]``,
+    attribute stateless, wrap ``Stateless`` around its type definition, e.g ``Stateless[List[int]]``,
     ``Stateless[str]``.
 
     Examples

--- a/ablator/config/types.py
+++ b/ablator/config/types.py
@@ -4,7 +4,6 @@ Custom types for runtime checking
 
 import typing as ty
 import inspect
-from typing import Any
 from collections import namedtuple
 from enum import Enum as _Enum
 
@@ -310,13 +309,13 @@ def _val2bool(val: str | bool) -> bool:
     raise ValueError(f"Cannot parse {val} as bool.")
 
 
-def _strip_hint_state(type_hint: type[Any]) -> tuple:
+def _strip_hint_state(type_hint: type[ty.Any]) -> tuple:
     """
     Strips the hint state from a type hint.
 
     Parameters
     ----------
-    type_hint : type[Any]
+    type_hint : type[ty.Any]
         The input type hint to strip the state from.
 
     Returns
@@ -339,13 +338,13 @@ def _strip_hint_state(type_hint: type[Any]) -> tuple:
     return Stateful, type_hint
 
 
-def _strip_hint_optional(type_hint: type[Any]) -> tuple:
+def _strip_hint_optional(type_hint: type[ty.Any]) -> tuple:
     """
     Strips the optional part of a type hint.
 
     Parameters
     ----------
-    type_hint : type[Any]
+    type_hint : type[ty.Any]
         The input type hint to strip the optional part from.
 
     Returns
@@ -365,13 +364,13 @@ def _strip_hint_optional(type_hint: type[Any]) -> tuple:
     return False, type_hint
 
 
-def _strip_hint_collection(type_hint: type[Any]) -> tuple:
+def _strip_hint_collection(type_hint: type[ty.Any]) -> tuple:
     """
     Strips the collection from a type hint.
 
     Parameters
     ----------
-    type_hint : type[Any]
+    type_hint : type[ty.Any]
         The input type hint to strip the collection from.
 
     Returns
@@ -419,15 +418,15 @@ def _strip_hint_collection(type_hint: type[Any]) -> tuple:
     )
 
 
-def parse_type_hint(cls: Any, type_hint: type[Any]) -> Annotation:
+def parse_type_hint(cls: ty.Any, type_hint: type[ty.Any]) -> Annotation:
     """
     Parses a type hint and returns a parsed annotation.
 
     Parameters
     ----------
-    cls : Any
+    cls : ty.Any
         The class being annotated.
-    type_hint : type[Any]
+    type_hint : type[ty.Any]
         The input type hint to parse.
 
     Returns
@@ -455,19 +454,19 @@ def parse_type_hint(cls: Any, type_hint: type[Any]) -> Annotation:
     )
 
 
-def _parse_class(cls: Any, args_kwargs: dict | object, debug: bool = False) -> object:
+def _parse_class(cls: ty.Any, args_kwargs: dict | object, debug: bool = False) -> object:
     """
     Parse values whose types are not  a collection or in ALLOWED_TYPES
     eg. bool, added dict(tune configs)
 
     Parameters
     ----------
-    cls : Any
+    cls : ty.Any
         The input Type
     args_kwargs : dict | object
         The positional and keyword arguments or object to parse with the given type
-    debug : bool, optional, default=False
-        Whether to load the configuration in debug mode, and ignore discrepancies/errors.
+    debug : bool, optional
+        Whether to load the configuration in debug mode, and ignore discrepancies/errors, by default ``False``
 
     Returns
     -------
@@ -512,24 +511,23 @@ def _parse_class(cls: Any, args_kwargs: dict | object, debug: bool = False) -> o
     return cls(*args, **kwargs)
 
 
-# flake8: noqa: C901
 # pylint: disable=too-complex
 def parse_value(
-    val: Any, annot: Annotation, name: str | None = None, debug: bool = False
+    val: ty.Any, annot: Annotation, name: str | None = None, debug: bool = False
 ) -> ty.Any:
     """
     Parses a value based on the given annotation.
 
     Parameters
     ----------
-    val : Any
+    val : ty.Any
         The input value to parse.
     annot : Annotation
         The annotation namedtuple to guide the parsing.
     name : str | None
         The name of the value, by default ``None``.
-    debug : bool, optional, default=False
-        Whether to load the configuration in debug mode, and ignore discrepencies / errors.
+    debug : bool, optional
+        Whether to load the configuration in debug mode, and ignore discrepencies / errors, by default ``False``
 
     Returns
     -------

--- a/ablator/config/utils.py
+++ b/ablator/config/utils.py
@@ -8,7 +8,7 @@ from functools import reduce
 
 
 def flatten_nested_dict(
-    dict_: dict, expand_list=True, seperator="."
+    dict_: dict, expand_list: bool = True, seperator: str = "."
 ) -> dict[str, ty.Any]:
     """
     Flattens a nested dictionary, expanding lists and tuples if specified.
@@ -17,9 +17,9 @@ def flatten_nested_dict(
     ----------
     dict_ : dict
         The input dictionary to be flattened.
-    expand_list : bool, optional
+    expand_list : bool
         Whether to expand lists and tuples in the dictionary, by default ``True``.
-    seperator : str, optional
+    seperator : str
         The separator used for joining the keys, by default ``"."``.
 
     Returns
@@ -52,16 +52,18 @@ def flatten_nested_dict(
     return flatten_dict
 
 
-def dict_hash(*dictionaries: list[dict[str, ty.Any]], hash_len=4):
+def dict_hash(
+    *dictionaries: list[dict[str, ty.Any]] | dict[str, ty.Any], hash_len: int = 4
+) -> str:
     """
     Calculates the MD5 hash of one or more dictionaries.
 
     Parameters
     ----------
-    *dictionaries : list[dict[str, ty.Any]]
+    *dictionaries : list[dict[str, ty.Any]] | dict[str, ty.Any]
         One or more dictionaries to calculate the hash for.
-    hash_len : int, optional
-        The length of the hash to return, by default 4.
+    hash_len : int
+        The length of the hash to return, by default = 4.
 
     Returns
     -------

--- a/ablator/config/utils.py
+++ b/ablator/config/utils.py
@@ -98,6 +98,7 @@ def dict_hash(
 
 
 # pylint: disable=bare-except
+# flake8: noqa: E722
 def _parse_fn_repr(val, fn_name):
     try:
         kwargs = getattr(val, fn_name)
@@ -130,6 +131,7 @@ def _parse_ast_repr(str_repr):
 
 
 # pylint: disable=bare-except,unnecessary-dunder-call
+# flake8: noqa: E722
 def parse_repr_to_kwargs(
     obj: ty.Any,
 ) -> tuple[tuple, dict[str, int | float | str | bool | None]]:

--- a/ablator/main/hpo/__init__.py
+++ b/ablator/main/hpo/__init__.py
@@ -1,3 +1,3 @@
-from ablator.main.hpo.optuna import OptunaSampler  # type: ignore
+from ablator.main.hpo.optuna import OptunaSampler
 from ablator.main.hpo.grid import GridSampler
 from ablator.main.hpo.base import BaseSampler

--- a/ablator/main/hpo/base.py
+++ b/ablator/main/hpo/base.py
@@ -27,10 +27,15 @@ class BaseSampler(ABC):
         ----------
         trial_id : int
             the trial_id which was returned when running ``eager_sampler``
-        metrics : dict[str, float]
+        metrics : dict[str, float] | None
             a metric dictionary corresponding to the updated metrics.
         state : TrialState
             the updated trial state
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented by the subclasses.
         """
         raise NotImplementedError
 
@@ -52,6 +57,11 @@ class BaseSampler(ABC):
             Otherwise a dictionary with keys as the internal configuration names and values, the
             corresponding values.
 
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented by the subclasses.
+
         """
         raise NotImplementedError
 
@@ -62,6 +72,7 @@ class BaseSampler(ABC):
         """
         raise NotImplementedError
 
+    # flake8: noqa
     def eager_sample(self) -> tuple[int, dict[str, ty.Any], None | dict[str, ty.Any]]:
         """
         eager_sample A sampled trial can be erroneous, for this reason we eagerly sample
@@ -69,7 +80,7 @@ class BaseSampler(ABC):
 
         Returns
         -------
-        tuple[int | dict[str, ty.Any]]
+        tuple[int, dict[str, ty.Any], None | dict[str, ty.Any]]
             a tuple that contains the trial id and the sampled configuration from the search space.
 
         Raises

--- a/ablator/main/hpo/base.py
+++ b/ablator/main/hpo/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 import typing as ty
 
 from ablator.main.state.store import TrialState
@@ -18,7 +19,7 @@ class BaseSampler(ABC):
 
     @abstractmethod
     def update_trial(
-        self, trial_id: int, metrics: dict[str, float] | None, state: TrialState
+        self, trial_id: int, metrics: OrderedDict[str, float] | None, state: TrialState
     ):
         """
         Update the trial state given the trial_id, the updated metrics, and the current trial state.
@@ -27,7 +28,7 @@ class BaseSampler(ABC):
         ----------
         trial_id : int
             the trial_id which was returned when running ``eager_sampler``
-        metrics : dict[str, float] | None
+        metrics : OrderedDict[str, float] | None
             a metric dictionary corresponding to the updated metrics.
         state : TrialState
             the updated trial state

--- a/ablator/main/hpo/base.py
+++ b/ablator/main/hpo/base.py
@@ -72,7 +72,7 @@ class BaseSampler(ABC):
         """
         raise NotImplementedError
 
-    # flake8: noqa
+    # flake8: noqa: DOC502
     def eager_sample(self) -> tuple[int, dict[str, ty.Any], None | dict[str, ty.Any]]:
         """
         eager_sample A sampled trial can be erroneous, for this reason we eagerly sample

--- a/ablator/main/hpo/grid.py
+++ b/ablator/main/hpo/grid.py
@@ -22,7 +22,7 @@ def _parse_search_space(space: SearchSpace) -> list:
     if space.categorical_values is not None:
         return space.categorical_values
     if space.subspaces is not None:
-        return [_ for _v in space.subspaces for _ in _parse_search_space(_v)]  # type: ignore
+        return [_ for _v in space.subspaces for _ in _parse_search_space(_v)]
     raise ValueError(f"Invalid SearchSpace: {space}")
 
 
@@ -106,7 +106,7 @@ class GridSampler(BaseSampler):
         self._lock = False
         self._rng = np.random.default_rng(seed)
         # mypy error because of nested dictionary
-        self._rng.shuffle(self.configs)  # type: ignore
+        self._rng.shuffle(self.configs) # type: ignore[arg-type]
 
     @property
     def _idx(self):

--- a/ablator/main/hpo/grid.py
+++ b/ablator/main/hpo/grid.py
@@ -9,7 +9,7 @@ from ablator.config.hpo import SearchSpace
 from ablator.main.hpo.base import BaseSampler
 
 
-def _parse_search_space(space: SearchSpace):
+def _parse_search_space(space: SearchSpace) -> list:
     if space.sub_configuration is not None:
         return _expand_search_space(space.sub_configuration.arguments)
     if space.value_range is not None:
@@ -26,7 +26,11 @@ def _parse_search_space(space: SearchSpace):
     raise ValueError(f"Invalid SearchSpace: {space}")
 
 
-def _expand_configs(configs, value: dict[str, SearchSpace] | SearchSpace | ty.Any, key):
+def _expand_configs(
+    configs: list[dict[str, str | int | float | dict]],
+    value: dict[str, SearchSpace] | SearchSpace | ty.Any,
+    key,
+) -> list:
     _configs = []
     if isinstance(value, dict):
         expanded_space = _expand_search_space(value)
@@ -55,38 +59,39 @@ def _expand_search_space(
 
 
 class GridSampler(BaseSampler):
+    """
+    GridSampler, expands the grid-space into evenly spaced intervals. For example,
+    a search space over ``SearchSpace(value_range=[1,10], n_bins=10)`` will be discritized to
+    10 intervals [1,..,10]. If the search space is composed of integers, e.g. ``value_type='int'``
+    the search space will be rounded down via the default python `int()` implementation and only the unique subset
+    will be considered. As a result the discritized search-space can be smaller than n_bins. For example:
+    ``SearchSpace(value_range=[1,5], value_type='int', n_bins=1000)`` will produce a SearchSpace of ``{1,2,3,4,5}``.
+    In contrast, ``SearchSpace(value_range=[1,5], value_type='float', n_bins=1000)`` will
+    produce a SearchSpace of 1000 floats,
+    ``[1. , 1.004004  , 1.00800801, ... , 4.98798799, 4.99199199, 4.995996  , 5.]``.
+
+
+    Previous configurations can be supplied via the `configs` argument. If the configurations are not found in
+    the discretized search_space (could be because of numerical stability errors or poor instantiation)
+    they will be stored in memory. Any duplicate configurations will be removed from current sampling
+    memory.
+
+    Parameters
+    ----------
+    search_space : dict[str, SearchSpace]
+        A dictionary with keys the configuration name and the search space to sample from
+    configs : list[dict[str, ty.Any]] | None
+        Previous configurations to resume the state from, by default None
+    seed : int | None
+        A seed to use for the HPO sampler, by default None
+    """
+
     def __init__(
         self,
         search_space: dict[str, SearchSpace],
         configs: list[dict[str, ty.Any]] | None = None,
         seed: int | None = None,
     ) -> None:
-        """
-        GridSampler, expands the grid-space into evenly spaced intervals. For example,
-        a search space over ``SearchSpace(value_range=[1,10], n_bins=10)`` will be discritized to
-        10 intervals [1,..,10]. If the search space is composed of integers, e.g. ``value_type='int'``
-        the search space will be rounded down via the default python `int()` implementation and only the unique subset
-        will be considered. As a result the discritized search-space can be smaller than n_bins. For example:
-        ``SearchSpace(value_range=[1,5], value_type='int', n_bins=1000)`` will produce a SearchSpace of ``{1,2,3,4,5}``.
-        In contrast, ``SearchSpace(value_range=[1,5], value_type='float', n_bins=1000)`` will
-        produce a SearchSpace of 1000 floats,
-        ``[1. , 1.004004  , 1.00800801, ... , 4.98798799, 4.99199199, 4.995996  , 5.]``.
-
-
-        Previous configurations can be supplied via the `configs` argument. If the configurations are not found in
-        the discretized search_space (could be because of numerical stability errors or poor instantiation)
-        they will be stored in memory. Any duplicate configurations will be removed from current sampling
-        memory.
-
-        Parameters
-        ----------
-        search_space : dict[str, SearchSpace]
-            A dictionary with keys the configuration name and the search space to sample from
-        configs : list[dict[str, ty.Any]] | None, optional
-            Previous configurations to resume the state from, by default None
-        seed : int | None, optional
-            A seed to use for the HPO sampler, by default None
-        """
         super().__init__()
         self.search_space = search_space
         self.configs = _expand_search_space(search_space)
@@ -119,12 +124,12 @@ class GridSampler(BaseSampler):
     def _drop(self):
         self.sampled_configs.pop()
 
-    def update_trial(self, trial_id, metrics: dict[str, float] | None, state):
+    def update_trial(self, trial_id: int, metrics: dict[str, float] | None, state):
         """
         This function is a no-op for grid sampling as it is entirely random.
         """
 
-    def internal_repr(self, trial_id):
+    def internal_repr(self, trial_id: int) -> None:
         """
         This function is a no-op for grid sampling as it does not need a reason
         to maintain an internal representation of trials.

--- a/ablator/main/hpo/optuna.py
+++ b/ablator/main/hpo/optuna.py
@@ -165,14 +165,14 @@ class _Study:
             else:
                 raise ValueError(f"Unrecognized optim. Direction `{v}`")
 
-    def get_trials(self, deepcopy, states):
+    def get_trials(self, deepcopy: bool, states: list["_state_store.TrialState"]):
         assert deepcopy is False
         return [t for t in self.trials if t.state in states]
 
     def _is_multi_objective(self):
         return len(self.directions) > 1
 
-    def drop(self, trial_id):
+    def drop(self, trial_id: int):
         for i, trial in enumerate(self.trials):
             if trial.id_ == trial_id:
                 del self.trials[i]
@@ -188,13 +188,18 @@ class _Study:
             optim_metrics=self.optim_metrics,
         )
 
-    def get_trial(self, trial_id):
+    def get_trial(self, trial_id: int):
         for trial in self.trials:
             if trial.id_ == trial_id:
                 return trial
         raise RuntimeError(f"Trial {trial_id} was not found.")
 
-    def update(self, trial_id, metrics, state):
+    def update(
+        self,
+        trial_id: int,
+        metrics: OrderedDict[str, float] | None,
+        state: "_state_store.TrialState",
+    ):
         self.get_trial(trial_id).update(metrics, state)
 
 

--- a/ablator/main/model/main.py
+++ b/ablator/main/model/main.py
@@ -264,7 +264,7 @@ class ModelBase(ABC):
 
         Raises
         ------
-        AssertionError
+        RuntimeError
             If the ``train_dataloader`` is not defined or its length is 0.
         """
         if not hasattr(self, "train_dataloader") or len(self.train_dataloader) == 0:
@@ -736,10 +736,15 @@ class ModelBase(ABC):
             If True, tries to resume training from a checkpoint, by default False.
         remote_progress_bar : ty.Optional[RemoteProgressBar]
             A remote progress bar can be used to report metrics from the internal progress bar
-        from_chkpt: str | Path | None, optional
+        from_chkpt: Path | str | None, optional
             Path to the checkpoint to initialize the state from.
-        data_lock: Lock | None, optional
+        data_lock: ty.Optional[Lock], optional
             Use a Lock to avoid downloading data concurrently.
+
+        Raises
+        ------
+        RuntimeError
+            if the state is already initialized and `smoke_test`, `debug` and `resume` flag are False
         """
         if (
             self._is_init
@@ -840,7 +845,7 @@ class ModelBase(ABC):
             )
         self.current_checkpoint = current_checkpoint
 
-    def _load_model(self, checkpoint_path: Path, model_only: bool = False) -> None:
+    def _load_model(self, checkpoint_path: Path, model_only: bool = False):
         """
         Loads the model and its state from the checkpoint file at the specified path.
 
@@ -859,9 +864,6 @@ class ModelBase(ABC):
             If no valid checkpoint was found, such as an invalid path, and when `model_only=True` we check
             for differences between loaded and current configuration.
 
-        Returns
-        -------
-        None
         """
 
         if not hasattr(self, "run_config") or self.run_config is None:

--- a/ablator/main/model/main.py
+++ b/ablator/main/model/main.py
@@ -546,7 +546,7 @@ class ModelBase(ABC):
             raise ValueError(
                 "Invalid configuration. Must specify both `optim_metrics` and `optim_metric_name` or neither."
             )
-
+        optim_metric_name = str(optim_metric_name)
         if (
             optim_metric_name is not None
             and optim_metrics is not None
@@ -566,7 +566,7 @@ class ModelBase(ABC):
         )
         if all(missing_metrics) and scheduler_requires_metric:
             raise ValueError(
-                f"Must provide `optim_metrics` when using Scheduler = `{scheduler_config.name}`."  # type: ignore
+                f"Must provide `optim_metrics` when using Scheduler = `{getattr(scheduler_config,'name', 'N/A')}`."
             )
         if all(missing_metrics) and run_config.early_stopping_iter is not None:
             raise ValueError(
@@ -575,13 +575,13 @@ class ModelBase(ABC):
         if all(missing_metrics):
             return None, None
         if scheduler_requires_metric:
-            mode = scheduler_config.arguments.mode  # type: ignore
+            mode = scheduler_config.arguments.mode  # type: ignore[union-attr]
             if (direction := optim_direction.value) != mode:
                 self.logger.warn(
                     f"Different optim_metric_direction {direction} than "
                     f"scheduler.arguments.mode {mode}. Overwriting scheduler.arguments.mode."
                 )
-        return optim_direction, optim_metric_name  # type: ignore
+        return optim_direction, optim_metric_name
 
     def _init_class_attributes(self):
         """

--- a/ablator/main/model/wrapper.py
+++ b/ablator/main/model/wrapper.py
@@ -33,30 +33,27 @@ class ModelWrapper(ModelBase):
 
     Attributes
     ----------
-    model_class: torch.nn.Module
+    model_class : torch.nn.Module
         The model class to wrap.
-    model: torch.nn.Module
+    model : torch.nn.Module
         The model created from the model class or checkpoint
-    optimizer: Optimizer
+    optimizer : Optimizer
         The optimizer created from the optimizer config or checkpoint
-    scaler: GradScaler
+    scaler : GradScaler
         The scaler created from the scaler config or checkpoint
-    scheduler: Scheduler
+    scheduler : Scheduler
         The scheduler created from the scheduler config or checkpoint
+
+    Parameters
+    ----------
+    model_class : type[nn.Module]
+        The model class to wrap.
     """
 
     def __init__(
         self,
         model_class: type[nn.Module],
     ):
-        """
-        Initializes the model wrapper.
-
-        Parameters
-        ----------
-        model_class: torch.nn.Module
-            The model class to wrap.
-        """
         super().__init__(
             model_class=model_class,
         )
@@ -91,7 +88,7 @@ class ModelWrapper(ModelBase):
         self,
         save_dict: dict[str, ty.Any] | None = None,
         strict_load: bool = True,
-    ) -> None:
+    ):
         """
         Creates the model, optimizer, scheduler, and scaler from a saved checkpoint dictionary or from config. You can overwrite this
         function and ``save_dict()`` function to customize the saving and loading of the model, optimizer, and scheduler to
@@ -100,11 +97,11 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        save_dict: dict[str, ty.Any]
-            The saved checkpoint dictionary to load from.
-        strict_load: bool
-            Whether to throw an error for mismatched keys.
 
+        save_dict : dict[str, ty.Any] | None
+            The saved checkpoint dictionary to load from. By default ``None``.
+        strict_load : bool
+            Whether to throw an error for mismatched keys. By default ``True``
         """
         save_dict = {} if save_dict is None else save_dict
         scheduler_state = save_dict["scheduler"] if "scheduler" in save_dict else None
@@ -148,25 +145,25 @@ class ModelWrapper(ModelBase):
         model: nn.Module,
         optimizer: Optimizer,
         scheduler_config: SchedulerConfig | None = None,
-        scheduler_state: dict | None = None,
-    ) -> Scheduler | None:
+        scheduler_state: dict[str, ty.Any] | None = None,
+    ) -> ty.Optional[Scheduler]:
         """
         Creates the scheduler from the saved state or from config.
 
         Parameters
         ----------
-        model: nn.Module
+        model : nn.Module
             The model to create the scheduler for.
-        optimizer: Optimizer
+        optimizer : Optimizer
             The optimizer to create the scheduler for.
-        scheduler_config: SchedulerConfig
-            The scheduler config to create the scheduler from.
-        scheduler_state: dict[str, ty.Any]
-            The scheduler state to load the scheduler from.
+        scheduler_config : SchedulerConfig | None
+            The scheduler config to create the scheduler from. By Default None.
+        scheduler_state : dict[str, ty.Any] | None
+            The scheduler state to load the scheduler from. By Default None.
 
         Returns
         -------
-        scheduler: Scheduler
+        ty.Optional[Scheduler]
             The scheduler.
         """
         scheduler: ty.Optional[Scheduler] = None
@@ -193,16 +190,16 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        model: nn.Module
+        model : nn.Module
             The model to create the optimizer for.
-        optimizer_config: OptimizerConfig
-            The optimizer config to create the optimizer from.
-        optimizer_state: dict[str, ty.Any]
-            The optimizer state to load the optimizer from.
+        optimizer_config : OptimizerConfig | None
+            The optimizer config to create the optimizer from. By Default None.
+        optimizer_state : dict[str, ty.Any] | None
+            The optimizer state to load the optimizer from. By Default None.
 
         Returns
         -------
-        optimizer: Optimizer
+        Optimizer
             The optimizer.
         """
         optimizer: Optimizer
@@ -229,18 +226,20 @@ class ModelWrapper(ModelBase):
 
         return optimizer
 
-    def create_scaler(self, scaler_state: ty.Optional[dict] = None) -> GradScaler:
+    def create_scaler(
+        self, scaler_state: ty.Optional[dict[str, ty.Any]] = None
+    ) -> GradScaler:
         """
         Creates the scaler from the saved state or from config.
 
         Parameters
         ----------
-        scaler_state: dict[str, ty.Any]
-            The scaler state to load the scaler from.
+        scaler_state : ty.Optional[dict[str, ty.Any]]
+            The scaler state to load the scaler from. optional, by default ``None``
 
         Returns
         -------
-        scaler: GradScaler
+        GradScaler
             The scaler.
         """
         scaler = GradScaler(enabled=self.amp)
@@ -248,19 +247,16 @@ class ModelWrapper(ModelBase):
             scaler.load_state_dict(scaler_state)
         return scaler
 
-    def load_checkpoint(
-        self, save_dict: dict[str, ty.Any], model_only: bool = False
-    ) -> None:
+    def load_checkpoint(self, save_dict: dict[str, ty.Any], model_only: bool = False):
         """
         Loads the checkpoint from the save dict.
 
         Parameters
         ----------
-        save_dict: dict[str, ty.Any]
+        save_dict : dict[str, ty.Any]
             The save dict to load the checkpoint from.
-        model_only: bool
-            Whether to load only the model or include scheduler, optimizer and scaler.
-
+        model_only : bool
+            Whether to load only the model or include scheduler, optimizer and scaler. By default False.
 
         Notes
         -----
@@ -276,22 +272,21 @@ class ModelWrapper(ModelBase):
             strict_load=True,
         )
 
-    def to_device(self, data: Iterable, device=None) -> Iterable:
+    def to_device(self, data: Iterable, device: ty.Optional[str] = None) -> Iterable:
         """
         Moves the data to the specified device.
 
         Parameters
         ----------
-        data: Iterable
+        data : Iterable
             The data to move to the device.
-        device: ty.Optional[ty.Union[torch.device, str]]
+        device : ty.Optional[str]
             The device to move the data to. If ``None``, the device specified in the config is used.
 
         Returns
         -------
-        data: Iterable
+        Iterable
             The data on the device.
-
         """
         if device is None:
             device = self.device
@@ -305,14 +300,14 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        model: nn.Module
+        model : nn.Module
             The model to train.
-        batch: Iterable
+        batch : Iterable
             The batch of input data to pass through the model,it could be a list, dict or a single tensor.
 
         Returns
         -------
-        out: tuple[dict[str, torch.Tensor] | None, torch.Tensor | None]
+        tuple[dict[str, torch.Tensor] | None, torch.Tensor | None]
             The output of the model,contains current predictions and loss of the model
         """
         batch = self.to_device(batch)
@@ -334,15 +329,15 @@ class ModelWrapper(ModelBase):
     def _inc_iter(self):
         self.current_iteration += 1
 
-    def _is_step(self, step_interval):
+    def _is_step(self, step_interval: int) -> bool:
         return (
             step_interval > 0
             and self.current_iteration > 0
             and self.current_iteration % step_interval == 0
         )
 
-    # pylint: disable=too-complex
-    def _train_evaluation_step(self, smoke_test=False):
+    def _train_evaluation_step(self, smoke_test: bool = False):
+        # pylint: disable=too-complex
         is_best = False
         optim_metric = None
         # If we are within 10% of the start or end of an epoch, we skip
@@ -465,15 +460,16 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        batch: Iterable
+        batch : Iterable
             The batch of input data to pass through the model,it could be a list, dict or a single tensor.
 
         Returns
         -------
-        outputs: dict[str, torch.Tensor] | None
-            The output of the model.
-        train_metrics: dict[str, ty.Any]
-            The training metrics.
+        tuple[dict[str, torch.Tensor] | None, dict[str, ty.Any]]
+            - outputs : dict[str, torch.Tensor] | None
+                The output of the model.
+            - train_metrics: dict[str, ty.Any]
+                The training metrics.
         """
         model = self.model
         optimizer = self.optimizer
@@ -506,7 +502,7 @@ class ModelWrapper(ModelBase):
         verbose = self.verbose == "console"
         self.logger.info(msg, verbose=verbose)
 
-    def update_status(self):
+    def update_status(self) -> None:
         """
         Update the metrics with current training stats,
         and then all metrics (static and moving average) will be set as description for the ``tqdm`` progress.
@@ -574,10 +570,22 @@ class ModelWrapper(ModelBase):
             self._prev_update_time = 1
 
     @ty.final
-    def eval(self, smoke_test=False):
+    def eval(self, smoke_test: bool = False):
         """
         Evaluate the model then update scheduler and save checkpoint if the current iteration is an evaluation step.
         It also check if it is early stopping (check Model Configuration module for more details).
+
+        Parameters
+        ----------
+        smoke_test : bool
+            If True, for a smoke test. By default, False
+
+        Raises
+        ------
+        LossDivergedError
+            If the loss is diverged during eval.
+        TrainPlateauError
+            If loss begins to slow down dramatically.
         """
         # Evaluation step
         if self._is_step(self.eval_itr):
@@ -597,13 +605,18 @@ class ModelWrapper(ModelBase):
                 self.logger.info(f"Evaluation Step [{eval_step}] {msg}", verbose=False)
 
     @property
-    def total_steps(self):
+    def total_steps(self) -> int:  # type: ignore[override] # flake8: noqa
         """
         The total number of steps for training.
+
+        Returns
+        -------
+        int
+            total steps = epoch's length * number of epochs.
         """
         return self.epoch_len * self.epochs
 
-    def train_loop(self, smoke_test=False):
+    def train_loop(self, smoke_test: bool = False) -> dict[str, float]:
         """
         Train the model in many steps, evaluate the model and log the metrics for each iteration.
         metrics including static metrics like learning rate, along with validation and
@@ -611,8 +624,20 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        smoke_test: bool
+        smoke_test : bool
             Whether to run a smoke test.
+
+        Returns
+        -------
+        dict[str, float]
+            metrics after completion of training.
+
+        Raises
+        ------
+        ValueError
+            If model outputs are not stored in correct format.
+        LossDivergedError
+            If the loss diverged.
         """
         train_dataloader = self.train_dataloader
         generator = iter(train_dataloader)
@@ -666,18 +691,19 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        run_config : RunConfig | None, optional
-            The run config to use for training. If `None` the wrapper must have been initialized already.
-        smoke_test : bool, default=False
-            Whether to run a smoke test.
-        debug : bool, default=False
-            Whether to run in debug mode.
-        resume : bool, default=False
-            Whether to resume training the model from existing checkpoints and existing experiment state.
-
+        run_config : RunConfig | None
+            The run config to use for training. By Default ``None``
+        smoke_test : bool
+            Whether to run a smoke test. By default ``False``
+        debug : bool
+            Whether to run in debug mode. By default ``False``
+        resume : bool
+            Whether to resume training the model from existing checkpoints and existing experiment state. By Default ``False``
+        remote_progress_bar : ty.Optional[RemoteProgressBar]
+            Optionally, we can pass a remote progress bar to report progress of the training. By Default ``None``
         Returns
         -------
-        Metrics
+        dict[str, float]
             The metrics from the training.
         """
         if not self._is_init and not run_config is None:
@@ -726,17 +752,23 @@ class ModelWrapper(ModelBase):
         return self.metrics
 
     @ty.final
-    def evaluate(self, run_config: RunConfig, chkpt: str | Path | None = None):
+    def evaluate(
+        self, run_config: RunConfig, chkpt: str | Path | None = None
+    ) -> dict[str, dict[str, ty.Any]]:
         """
         Evaluate the model after training on the test and validation sets.
 
         Parameters
         ----------
-        run_config: RunConfig
+        run_config : RunConfig
             The run config to use for evaluation.
-        chkpt: str | Path | None, optional
-            Path to the checkpoint to evaluate. If None, the latest checkpoint is evaluated.
+        chkpt: str | Path | None
+            Path to the checkpoint to evaluate. If None, the latest checkpoint is evaluated. By Default ``None``
 
+        Returns
+        -------
+        dict[str, dict[str, ty.Any]]
+            Metrics
         """
         self.init_state(run_config, resume=True, from_chkpt=chkpt)
         self.logger.info(f"Evaluating {self.current_checkpoint}")
@@ -866,11 +898,11 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        model: nn.Module
+        model : nn.Module
             The model to apply the loss to.
-        loss: torch.Tensor | None
+        loss : torch.Tensor | None
             The loss to apply.
-        optimizer: Optimizer
+        optimizer : Optimizer
             The optimizer to step.
         scaler: torch.cuda.amp.GradScaler
             The scaler to use during mixed precision training.
@@ -945,15 +977,15 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        model: nn.Module
+        model : nn.Module
             The model to validate.
-        dataloader: DataLoader
+        dataloader : DataLoader
             The dataloader to use for validation.
-        metrics: Metrics
+        metrics : Metrics
             The metrics to use for validation.
-        subsample: float
-            The fraction of the dataloader to use for validation.
-        smoke_test: bool
+        subsample : float
+            The fraction of the dataloader to use for validation. By default = 1.0.
+        smoke_test : bool
             Whether to execute this function as a smoke test. If ``True``, only one iteration will be performed,
             which is useful for quickly checking if the code runs without errors. Default is ``False``.
 
@@ -1122,7 +1154,7 @@ class ModelWrapper(ModelBase):
 
         Parameters
         ----------
-        run_config: RunConfig
+        run_config : RunConfig
             The run configuration.
 
         Returns
@@ -1149,10 +1181,19 @@ class ModelWrapper(ModelBase):
         ...         )
         """
 
-    def config_parser(self, run_config: RunConfig):
+    def config_parser(self, run_config: RunConfig) -> RunConfig:
         """
         You can overwrite this function to initialize ``Derived`` properties that are not decided
         until the experiment is launched.
+
+        Parameters
+        ----------
+        run_config : RunConfig
+            The run config for the experiment.
+
+        Returns
+        -------
+        RunConfig
 
         Examples
         --------
@@ -1171,6 +1212,11 @@ class ModelWrapper(ModelBase):
         """
         This function is done post-initialization because otherwise the
         dataloaders are pickled with the object when running distributed.
+
+        Parameters
+        ----------
+        run_config : RunConfig
+            The run config for the experiment.
         """
         self.train_dataloader = self.make_dataloader_train(run_config)
         # pylint: disable=assignment-from-no-return
@@ -1178,15 +1224,15 @@ class ModelWrapper(ModelBase):
         # pylint: disable=assignment-from-no-return
         self.test_dataloader = self.make_dataloader_test(run_config)
 
-    def checkpoint(self, is_best=False):
+    def checkpoint(self, is_best: bool = False):
         """
         Save a checkpoint of the model.It will use the class name of the model as the filename.
 
 
         Parameters
         ----------
-        is_best: bool
-            Whether this is the best model so far.
+        is_best : bool
+            Whether this is the best model so far. By default ``False``
         """
         self.logger.checkpoint(
             self.current_state,
@@ -1206,6 +1252,10 @@ class ModelWrapper(ModelBase):
         -------
         dict[str, ty.Any]
             The current state of the trainer.
+            - model: the model's state
+            - optimizer: the state of optimizer
+            - scheduler: the scheduler's state
+            - scaler: the state of gradScaler.
         """
         model_state_dict = self.model.state_dict()
 

--- a/ablator/main/model/wrapper.py
+++ b/ablator/main/model/wrapper.py
@@ -90,10 +90,10 @@ class ModelWrapper(ModelBase):
         strict_load: bool = True,
     ):
         """
-        Creates the model, optimizer, scheduler, and scaler from a saved checkpoint dictionary or from config. You can overwrite this
-        function and ``save_dict()`` function to customize the saving and loading of the model, optimizer, and scheduler to
-        your needs. An example for this is shown in `Saving and loading multi-module models <./notebooks/Multi-Modules.ipynb>`_
-        tutorial.
+        Creates the model, optimizer, scheduler, and scaler from a saved checkpoint dictionary or from config.
+        You can overwrite this function and ``save_dict()`` function to customize the saving and loading of the
+        model, optimizer, and scheduler to your needs. An example for this is shown in
+        `Saving and loading multi-module models <./notebooks/Multi-Modules.ipynb>`_ tutorial.
 
         Parameters
         ----------
@@ -348,7 +348,7 @@ class ModelWrapper(ModelBase):
         ):
             self.train_metrics.evaluate(reset=False)
 
-        if self.val_dataloader is not None:
+        if self.val_dataloader is not None and self.eval_metrics is not None:
             self._validation_loop(
                 model=self.model,
                 dataloader=self.val_dataloader,
@@ -358,7 +358,7 @@ class ModelWrapper(ModelBase):
             )
         else:
             self.logger.warn(
-                "Validation dataloader was not set. Will be skipping `validation_loop`."
+                "Validation dataloader and metrics were not set. Will be skipping `validation_loop`."
             )
 
         if (
@@ -698,15 +698,20 @@ class ModelWrapper(ModelBase):
         debug : bool
             Whether to run in debug mode. By default ``False``
         resume : bool
-            Whether to resume training the model from existing checkpoints and existing experiment state. By Default ``False``
-        remote_progress_bar : ty.Optional[RemoteProgressBar]
-            Optionally, we can pass a remote progress bar to report progress of the training. By Default ``None``
+            Whether to resume training the model from existing checkpoints and
+            existing experiment state. By Default ``False``
         Returns
         -------
         dict[str, float]
             The metrics from the training.
+
+        Raises
+        ------
+        ValueError
+            if the state is not initialized and no `run_config` is provided or when a `run_config` is
+            provided but the state is already initialized.
         """
-        if not self._is_init and not run_config is None:
+        if not self._is_init and run_config is not None:
             self.init_state(
                 run_config=run_config,
                 smoke_test=smoke_test,
@@ -1056,7 +1061,7 @@ class ModelWrapper(ModelBase):
 
         Returns
         -------
-        dict[str, Callable]
+        dict[str, Callable] | None
             The evaluation functions to use. Also see ``Metrics`` for details.
 
         Examples

--- a/ablator/main/model/wrapper.py
+++ b/ablator/main/model/wrapper.py
@@ -111,16 +111,16 @@ class ModelWrapper(ModelBase):
         model_class = self.model_class
         model: nn.Module
         if (model_config := self.model_config) is not None:
-            model = model_class(model_config)  # type: ignore
+            model = model_class(model_config)
         else:
-            # Support of decleartive paradigm without model over-writing
+            # Support of declarative paradigm without model over-writing
             model = model_class()
 
         if "model" in save_dict:
             model.load_state_dict(save_dict["model"], strict=strict_load)
         elif inspect.ismethod(getattr(model, "init_weights", None)):
             # TODO tutorial on this use-case
-            model.init_weights()  # type: ignore
+            getattr(model, "init_weights")()
 
         model = model.to(self.device)
         optimizer = self.create_optimizer(
@@ -605,7 +605,7 @@ class ModelWrapper(ModelBase):
                 self.logger.info(f"Evaluation Step [{eval_step}] {msg}", verbose=False)
 
     @property
-    def total_steps(self) -> int:  # type: ignore[override] # flake8: noqa
+    def total_steps(self) -> int: # type: ignore[override]
         """
         The total number of steps for training.
 
@@ -885,11 +885,11 @@ class ModelWrapper(ModelBase):
             return
         step_when = self._scheduler_step_when
         if step_when == "train" or step_when is None:
-            scheduler.step(*args)  # type: ignore
+            scheduler.step(*args)
         elif step_when == "epoch" and self._is_step(self.epoch_len):
-            scheduler.step(*args)  # type: ignore
+            scheduler.step(*args)
         elif step_when == "val" and is_val_step:
-            scheduler.step(*args)  # type: ignore
+            scheduler.step(*args)
 
     def apply_loss(
         self,
@@ -1270,7 +1270,7 @@ class ModelWrapper(ModelBase):
 
         scheduler_state_dict = None
         if getattr(self, "scheduler", None) is not None:
-            scheduler_state_dict = self.scheduler.state_dict()  # type: ignore
+            scheduler_state_dict = self.scheduler.state_dict() # type: ignore[union-attr]
 
         scaler_state_dict = None
         if getattr(self, "scaler", None) is not None:

--- a/ablator/main/mp.py
+++ b/ablator/main/mp.py
@@ -248,7 +248,7 @@ class ParallelTrainer(ProtoTrainer):
             max_retries=max_error_retries,
         )(
             train_main_remote
-        ).options(  # type: ignore
+        ).options(
             resources={f"node:{node_ip}": 0.001}, name=trial_uuid
         )
         run_config.experiment_dir = (self.experiment_dir / trial_uuid).as_posix()
@@ -412,8 +412,8 @@ class ParallelTrainer(ProtoTrainer):
 
         if verbose == "progress":
             # pylint: disable=no-member
-            self._progress_bar = RemoteProgressBar.remote(self.total_trials)  # type: ignore
-            self._display = RemoteDisplay(self._progress_bar)  # type: ignore
+            self._progress_bar = RemoteProgressBar.remote(self.total_trials) # type: ignore[attr-defined]
+            self._display = RemoteDisplay(self._progress_bar) # type: ignore[arg-type]
 
         if ray.is_initialized():
             self.logger.warn(
@@ -457,7 +457,7 @@ class ParallelTrainer(ProtoTrainer):
         self.logger.to_remote()
         if self._gpu > 0:
             # pylint: disable=no-member
-            self.gpu_manager = GPUManager.remote()  # type: ignore
+            self.gpu_manager = GPUManager.remote() # type: ignore[attr-defined]
         else:
             self.gpu_manager = None
 
@@ -467,7 +467,7 @@ class ParallelTrainer(ProtoTrainer):
         self.logger.warn(diffs)
 
     # pylint: disable=arguments-renamed
-    def launch(  # type: ignore
+    def launch( # type: ignore[override]
         self,
         working_directory: str,
         auxilary_modules: list[tys.ModuleType] | None = None,

--- a/ablator/main/mp.py
+++ b/ablator/main/mp.py
@@ -53,12 +53,6 @@ class ParallelTrainer(ProtoTrainer):
         This attribute manages optuna trials.
     total_trials : int
         Number of trials to run.
-    gpu_mem_bottleneck : int
-        The minimum memory capacity of all available gpus.
-    cpu : float
-        The number of cpu used per trial.
-    gpu : float
-        The number of gpu used per trial.
 
     Examples
     --------

--- a/ablator/main/mp.py
+++ b/ablator/main/mp.py
@@ -97,7 +97,8 @@ class ParallelTrainer(ProtoTrainer):
     ...     "model_config.activation": SearchSpace(categorical_values = ["relu", "elu", "leakyRelu"]),
     ... }
 
-    - Define run config (remember to redefine the parallel config to update the model config type to be ``CustomModelConfig``):
+    - Define run config (remember to redefine the parallel config to
+    update the model config type to be ``CustomModelConfig``):
 
     >>> @configclass
     >>> class CustomParallelConfig(ParallelConfig):
@@ -177,6 +178,11 @@ class ParallelTrainer(ProtoTrainer):
         -------
         float
             mock gpu value i.e. 0.001
+
+        Raises
+        ------
+        ValueError
+            if the `gpu_mb_per_experiment` configuration is not specified when using `device='cuda'`
         """
         device = butils.parse_device(self.run_config.device)
         if not device.startswith("cuda"):
@@ -196,7 +202,7 @@ class ParallelTrainer(ProtoTrainer):
 
         Returns
         -------
-        int | float
+        float
             a virtual number of _cpus to use i.e. 0.001
         """
         if (
@@ -468,7 +474,7 @@ class ParallelTrainer(ProtoTrainer):
         ray_head_address: str | None = None,
         resume: bool = False,
         excluding_files: list[str] | None = None,
-    ) -> None:
+    ):
         """
         Set up and launch the parallel ablation process. This sets up a ray cluster, and trials of different
         hyperparameters initialized (or retrieved) will be pushed to ray nodes so they can be executed in parallel.
@@ -482,14 +488,12 @@ class ParallelTrainer(ProtoTrainer):
         ray_head_address : str | None
             Ray cluster address.
         resume : bool
-            Whether to resume training the model from existing checkpoints and existing experiment state. By default False
+            Whether to resume training the model from existing checkpoints and
+            existing experiment state. By default False
         excluding_files : list[str] | None
             A list of files in `.gitignore` format, that will be excluded from being uploaded to the ray cluster.
             If unspecified it ignores `.git/**` folder.
 
-        Returns
-        -------
-        None
         """
         try:
             torch.multiprocessing.set_start_method("spawn")

--- a/ablator/main/proto.py
+++ b/ablator/main/proto.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import git
 from git import exc
+import typing as ty
 import torch
 
 from ablator.config.proto import RunConfig
@@ -13,6 +14,13 @@ from ablator.main.model.wrapper import ModelWrapper
 class ProtoTrainer:
     """
     Manages resources for Prototyping. This trainer runs an experiment of a single prototype model. (Therefore no HPO)
+
+    Parameters
+    ----------
+    wrapper : ModelWrapper
+        The main model wrapper.
+    run_config : RunConfig
+        Running configuration for the model.
 
     Attributes
     ----------
@@ -91,16 +99,7 @@ class ProtoTrainer:
         wrapper: ModelWrapper,
         run_config: RunConfig,
     ):
-        """
-        Initialize model wrapper and running configuration for the model.
-
-        Parameters
-        ----------
-        wrapper : ModelWrapper
-            The main model wrapper.
-        run_config : RunConfig
-            Running configuration for the model.
-        """
+        # Initialize model wrapper and running configuration for the model.
         super().__init__()
         self.wrapper = copy.deepcopy(wrapper)
         self.run_config: RunConfig = copy.deepcopy(run_config)
@@ -142,7 +141,7 @@ class ProtoTrainer:
                 "to keep track of changes."
             )
 
-    def launch(self, working_directory: str, debug: bool = False):
+    def launch(self, working_directory: str, debug: bool = False) -> dict[str, float]:
         """
         Launch the prototype experiment (train, evaluate the single prototype model) and return metrics.
 
@@ -152,11 +151,11 @@ class ProtoTrainer:
             The working directory points to a git repository that is used for keeping track
             the code differences.
         debug : bool, default=False
-            Whether to train model in debug mode.
+            Whether to train model in debug mode. By default False
 
         Returns
         -------
-        metrics : Metrics
+        metrics : dict[str, float]
             Metrics returned after training.
         """
         self._mount()
@@ -169,28 +168,35 @@ class ProtoTrainer:
         metrics = self.wrapper.train(debug=debug)
         return metrics
 
-    def evaluate(self):
+    def evaluate(self) -> dict[str, dict[str, ty.Any]]:
         """
         Run model evaluation on the training results, sync evaluation results to external logging services
         (e.g Google cloud storage, other remote servers).
 
         Returns
         -------
-        metrics : Metrics
+        metrics : dict[str, dict[str, ty.Any]]
             Metrics returned after evaluation.
         """
         # TODO load model if it is un-trained
         metrics = self.wrapper.evaluate(self.run_config)
         return metrics
 
-    def smoke_test(self, config=None):
+    def smoke_test(self, config: RunConfig | None = None):
         """
         Run a smoke test training process on the model.
 
         Parameters
         ----------
-        config : RunConfig
+        config : RunConfig | None
             Running configuration for the model.
+
+        Examples
+        --------
+        try:
+            ablator.smoke_test(run_config)
+        except err:
+            raise err
         """
         if config is None:
             config = self.run_config

--- a/ablator/main/proto.py
+++ b/ablator/main/proto.py
@@ -1,11 +1,11 @@
 import copy
+import typing as ty
 from copy import deepcopy
 from pathlib import Path
 
 import git
-from git import exc
-import typing as ty
 import torch
+from git import exc
 
 from ablator.config.proto import RunConfig
 from ablator.main.model.wrapper import ModelWrapper
@@ -134,7 +134,7 @@ class ProtoTrainer:
             ) from e
         except exc.NoSuchPathError as e:
             raise FileNotFoundError(f"Directory {working_dir} was not found. ") from e
-        except exc.InvalidGitRepositoryError as e:
+        except exc.InvalidGitRepositoryError:
             return (
                 f"No git repository was detected at {working_dir}. "
                 "We recommend setting the working directory to a git repository "
@@ -150,7 +150,7 @@ class ProtoTrainer:
         working_directory : str
             The working directory points to a git repository that is used for keeping track
             the code differences.
-        debug : bool, default=False
+        debug : bool, optional
             Whether to train model in debug mode. By default False
 
         Returns

--- a/ablator/main/state/_utils.py
+++ b/ablator/main/state/_utils.py
@@ -8,7 +8,7 @@ from ablator.config.proto import Optim
 from ablator.utils.file import nested_set
 
 
-def verify_metrics(metrics: dict[str, float] | None):
+def verify_metrics(metrics: dict[str, float] | None) -> None:
     if metrics is None:
         return
     for k, v in metrics.items():
@@ -30,14 +30,14 @@ def augment_trial_kwargs(
 
     Parameters
     ----------
-    trial_kwargs : dict
+    trial_kwargs : dict[str, ty.Any]
         The dictionary containing the key-value pairs to be augmented.
-    augmentation : dict
+    augmentation : dict[str, ty.Any]
         The dictionary containing the additional key-value pairs.
 
     Returns
     -------
-    dict
+    dict[str, ty.Any]
         The augmented dictionary.
 
     Examples
@@ -61,8 +61,8 @@ def augment_trial_kwargs(
 
 
 def parse_metrics(
-    metric_directions: dict[str, Optim], metrics: dict[str, float] | None
-) -> dict[str, float] | None:
+    metric_directions: OrderedDict[str, Optim], metrics: dict[str, float] | None
+) -> OrderedDict[str, float] | None:
     """
     Convert metrics to ordered dictionary of float values and use their direction (minimize or maximize)
     if they are missing or are invalid to set to inf and -inf respectively. Returns the subet of metrics
@@ -70,15 +70,20 @@ def parse_metrics(
 
     Parameters
     ----------
-    metric_directions : dict
+    metric_directions : OrderedDict
         The ordered dictionary containing the directions of the metrics (minimize or maximize).
-    metrics : dict
+    metrics : dict | None
         The dictionary containing the metric values.
 
     Returns
     -------
-    OrderedDict
+    OrderedDict | None
         The ordered dictionary of metric values converted to float using their direction.
+
+    Raises
+    ------
+    KeyError
+        If any key from metrics_directions not found in metrics.
 
     Examples
     --------

--- a/ablator/main/state/_utils.py
+++ b/ablator/main/state/_utils.py
@@ -70,14 +70,14 @@ def parse_metrics(
 
     Parameters
     ----------
-    metric_directions : OrderedDict
+    metric_directions : OrderedDict[str, Optim]
         The ordered dictionary containing the directions of the metrics (minimize or maximize).
-    metrics : dict | None
+    metrics : dict[str, float] | None
         The dictionary containing the metric values.
 
     Returns
     -------
-    OrderedDict | None
+    OrderedDict[str, float] | None
         The ordered dictionary of metric values converted to float using their direction.
 
     Raises

--- a/ablator/main/state/state.py
+++ b/ablator/main/state/state.py
@@ -26,6 +26,34 @@ from ablator.main.state._utils import (
 
 
 class ExperimentState:
+    """
+    Initializes the ExperimentState.
+    Initialize databases for storing training states and a sampler
+    Create trials based on total num of trials specified in config
+
+    Parameters
+    ----------
+    experiment_dir : Path
+        The directory where the experiment data will be stored.
+    config : ParallelConfig
+        The configuration object that defines the experiment settings.
+    logger : FileLogger | None
+        The logger for outputting experiment logs. If not specified, a dummy logger will be used. By Default ``None``.
+    resume : bool
+        Whether to resume a previously interrupted experiment. By default ``False``.
+    sampler_seed : int | None
+        The seed to use for the trial sampler. By Default ``None``.
+
+    Raises
+    ------
+    RuntimeError
+        If the specified ``search_space`` parameter is not found in the configuration.
+    AssertionError
+        If ``config.search_space`` is empty.
+    RuntimeError
+        if the experiment database already exists and ``resume`` is ``False``.
+    """
+
     def __init__(
         self,
         experiment_dir: Path,
@@ -34,33 +62,6 @@ class ExperimentState:
         resume: bool = False,
         sampler_seed: int | None = None,
     ) -> None:
-        """
-        Initializes the ExperimentState.
-        Initialize databases for storing training states and a sampler
-        Create trials based on total num of trials specified in config
-
-        Parameters
-        ----------
-        experiment_dir : Path
-            The directory where the experiment data will be stored.
-        config : ParallelConfig
-            The configuration object that defines the experiment settings.
-        logger : FileLogger, optional
-            The logger to use for outputting experiment logs. If not specified, a dummy logger will be used.
-        resume : bool, optional
-            Whether to resume a previously interrupted experiment. Default is ``False``.
-        sampler_seed : int | None
-            The seed to use for the trial sampler. Default is ``None``.
-
-        Raises
-        ------
-        RuntimeError
-            If the specified ``search_space`` parameter is not found in the configuration.
-        AssertionError
-            If ``config.search_space`` is empty.
-        RuntimeError
-            if the experiment database already exists and ``resume`` is ``False``.
-        """
         self.config = config
         self.logger: FileLogger = logger if logger is not None else butils.Dummy()  # type: ignore
 
@@ -138,7 +139,7 @@ class ExperimentState:
 
         Returns
         -------
-        dict[str, Any]
+        dict[str, ty.Any]
             A dictionary of parameter names and their corresponding values.
 
         Examples
@@ -210,8 +211,27 @@ class ExperimentState:
 
     def __sample_trial(
         self,
-        ignore_errors=False,
+        ignore_errors: bool = False,
     ) -> tuple[int, ParallelConfig]:
+        """
+        Parameters
+        ----------
+        ignore_errors : bool
+            To ignore errors.
+
+        Returns
+        -------
+        tuple[int, ParallelConfig]
+
+        Raises
+        ------
+        StopIteration
+            If the number of invalid trials sampled exceeds the internal upper bound (`20`) or the
+            sampler raises a StopIteration exception indicating that the search space has been exhaustively
+            evaluated.
+        TypeError
+            If the trial parameter are invalid and `config.ignore_invalid_params` is set to False
+        """
         error_upper_bound = 20
         errored_trials = 0
         i = 0
@@ -282,10 +302,15 @@ class ExperimentState:
         ----------
         trial_id : int
             The id of the trial to update.
-        metrics : dict[str, float] | None, optional
-            The metrics of the trial, by default ``None``.
-        state : TrialState, optional
-            The state of the trial, by default ``TrialState.RUNNING``.
+        metrics : dict[str, float] | None
+            The metrics of the trial. By default ``None``.
+        state : TrialState
+            The state of the trial, by default ``TrialState.RUNNING``. (Optional)
+
+        Raises
+        ------
+        RuntimeError
+            if the experiment state is corrupted, i.e repeating trials are found.
 
         Examples
         --------
@@ -307,7 +332,7 @@ class ExperimentState:
 
     def _update_internal_trial_state(
         self, trial_id: int, metrics: dict[str, float] | None, state: TrialState
-    ):
+    ) -> bool:
         """
         Update the state of a trial in the Experiment state database.
 
@@ -324,6 +349,11 @@ class ExperimentState:
         -------
         bool
             True if the update was successful.
+
+        Raises
+        ------
+        RuntimeError
+            If the trial associated with the ``trial_id`` is not found.
         """
 
         with Session(self.engine) as session:
@@ -384,6 +414,12 @@ class ExperimentState:
             The optuna trial number.
         trial_state : TrialState
             The state of the trial.
+        _opt_distributions_kwargs : dict[str, ty.Any] | None
+            Optuna distribution kwargs, by default None.
+        _opt_distributions_types : dict[str, str] | None
+            Optuna distribution types, by default None
+        _opt_params : dict[str, ty.Any] | None
+            Optuna params, by default None.
         """
         with Session(self.engine) as session:
             trial = Trial(
@@ -406,9 +442,21 @@ class ExperimentState:
         return trials
 
     def valid_trials_id(self) -> list[int]:
+        """
+        Returns
+        -------
+        list[int]
+            trial ids of all the valid trials.
+        """
         return [c.id for c in self.valid_trials()]
 
     def valid_trials(self) -> list[Trial]:
+        """
+        Returns
+        -------
+        list[Trial]
+            All the valid trials (the are not pruned [Duplicated or Invalid]).
+        """
         stmt = select(Trial).where(
             (Trial.state != TrialState.PRUNED_DUPLICATE)
             & (Trial.state != TrialState.PRUNED_INVALID)
@@ -417,6 +465,19 @@ class ExperimentState:
         return trials
 
     def get_trials_by_state(self, state: TrialState) -> list[Trial]:
+        """
+        To get all the trials in the given state.
+
+        Parameters
+        ----------
+        state : TrialState
+            Represents the state of a trial.
+
+        Returns
+        -------
+        list[Trial]
+            List of all the trials in that given state.
+        """
         assert state in {
             TrialState.PRUNED,
             TrialState.COMPLETE,
@@ -433,6 +494,19 @@ class ExperimentState:
         return trials
 
     def get_trial_configs_by_state(self, state: TrialState) -> list[ParallelConfig]:
+        """
+        To get all the trial's configuration in the given state.
+
+        Parameters
+        ----------
+        state : TrialState
+            The state of a trial.
+
+        Returns
+        -------
+        list[ParallelConfig]
+            List of configurations of all the trials in that state.
+        """
         assert (
             state != TrialState.PRUNED_INVALID
         ), "Can not return configuration for invalid trials due to configuration errors."

--- a/ablator/main/state/state.py
+++ b/ablator/main/state/state.py
@@ -63,7 +63,9 @@ class ExperimentState:
         sampler_seed: int | None = None,
     ) -> None:
         self.config = config
-        self.logger: FileLogger = logger if logger is not None else butils.Dummy()  # type: ignore
+        self.logger: FileLogger | butils.Dummy = (
+            logger if logger is not None else butils.Dummy()
+        )
 
         default_vals = [
             v
@@ -124,7 +126,7 @@ class ExperimentState:
             raise NotImplementedError
         for trial in self.get_trials_by_state(TrialState.RUNNING):
             # mypy error for sqlalchemy types
-            trial_id = int(trial.trial_num)  # type: ignore
+            trial_id: int = trial.trial_num  # type: ignore[assignment]
             self.update_trial_state(trial_id, None, TrialState.WAITING)
 
     @staticmethod
@@ -200,8 +202,8 @@ class ExperimentState:
         if len(pending_trials) > 0:
             trial = random.choice(pending_trials)
             # mypy errors for sqlalchemy types
-            trial_id = int(trial.trial_num)  # type: ignore
-            trial_config = type(self.config)(**trial.config_param)  # type: ignore
+            trial_id: int = trial.trial_num  # type: ignore[assignment]
+            trial_config = type(self.config)(**trial.config_param)
             self._update_internal_trial_state(trial_id, None, TrialState.RUNNING)
             return trial_id, trial_config
 
@@ -363,7 +365,7 @@ class ExperimentState:
                 raise RuntimeError(f"Trial {trial_id} was not found.")
             if metrics is not None:
                 res.metrics.append(metrics)
-            res.state = state  # type: ignore # TODO fix this
+            res.state = state # type: ignore[assignment]
             session.commit()
             session.flush()
 
@@ -439,7 +441,7 @@ class ExperimentState:
 
     def _get_trials_by_stmt(self, stmt) -> list[Trial]:
         with self.engine.connect() as conn:
-            trials: list[Trial] = conn.execute(stmt).fetchall()  # type: ignore
+            trials: list[Trial] = conn.execute(stmt).fetchall()  # type: ignore[assignment]
         return trials
 
     def valid_trials_id(self) -> list[int]:

--- a/ablator/main/state/state.py
+++ b/ablator/main/state/state.py
@@ -176,6 +176,7 @@ class ExperimentState:
 
         return msg
 
+    # flake8: noqa: DOC502
     def sample_trial(self) -> tuple[int, ParallelConfig]:
         """
         Samples a trial from the search space and persists the trial state to the experiment database.

--- a/ablator/main/state/store.py
+++ b/ablator/main/state/store.py
@@ -69,7 +69,8 @@ class Trial(Base):
     state: Mapped[PickleType]
         The ``TrialState``
     runtime_errors: Mapped[int]
-        Total runtime errors that the trial encountered and are incremented every time the trial faces a recoverable error.
+        Total runtime errors that the trial encountered and are incremented
+        every time the trial faces a recoverable error.
     """
 
     __tablename__ = "trial"

--- a/ablator/main/state/store.py
+++ b/ablator/main/state/store.py
@@ -35,18 +35,43 @@ class TrialState(enum.IntEnum):
 
     """
 
-    RUNNING = 0
-    COMPLETE = 1
-    PRUNED = 2
-    FAIL = 3
-    WAITING = 4
-    PRUNED_INVALID = 5
-    PRUNED_DUPLICATE = 6
-    PRUNED_POOR_PERFORMANCE = 7
-    FAIL_RECOVERABLE = 8
+    RUNNING: int = 0
+    COMPLETE: int = 1
+    PRUNED: int = 2
+    FAIL: int = 3
+    WAITING: int = 4
+    PRUNED_INVALID: int = 5
+    PRUNED_DUPLICATE: int = 6
+    PRUNED_POOR_PERFORMANCE: int = 7
+    FAIL_RECOVERABLE: int = 8
 
 
 class Trial(Base):
+    """
+    Class to store adata about trial.
+
+    Attributes
+    ----------
+    id: Mapped[int]
+        The trial Id used for internal purposes
+    config_uid: Mapped[str]
+        The configuration identifier associated with the trial's unique attributes
+    metrics: Mapped[PickleType]
+        The performance metrics dictionary associated as reported by the trial.
+        Dict[str,float] where str is the metric name and float is the metric value.
+    config_param: Mapped[PickleType]
+        The configuration parameters for the specific trial including the defaults.
+    aug_config_param: Mapped[PickleType]
+        The augmenting configuration as picked by the config sampler.
+        It is the values only different from the default config (excl. Derived properties)
+    trial_num: Mapped[Integer]
+        The trial_num corresponding to the internal HPO sampler, used to communicate with the sampler.
+    state: Mapped[PickleType]
+        The ``TrialState``
+    runtime_errors: Mapped[int]
+        Total runtime errors that the trial encountered and are incremented every time the trial faces a recoverable error.
+    """
+
     __tablename__ = "trial"
     id: Mapped[int] = mapped_column(primary_key=True)
     config_uid: Mapped[str] = mapped_column(String(30))

--- a/ablator/modules/loggers/file.py
+++ b/ablator/modules/loggers/file.py
@@ -17,11 +17,20 @@ class FileLogger:
         ANSI escape code for the error text color.
     ENDC : str
         ANSI escape code for resetting the text color.
+
+    Parameters
+    ----------
+    path : str | Path | None
+        Path to the log file, by default ``None``.
+    verbose : bool
+        Whether to print messages to the console, by default ``True``.
+    prefix : str | None
+        A prefix to add to each logged message, by default ``None``.
     """
 
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
+    WARNING: str = "\033[93m"
+    FAIL: str = "\033[91m"
+    ENDC: str = "\033[0m"
 
     def __init__(
         self,
@@ -29,18 +38,7 @@ class FileLogger:
         verbose: bool = True,
         prefix: str | None = None,
     ):
-        """
-        Initialize a FileLogger.
-
-        Parameters
-        ----------
-        path : str | Path | None, optional
-            Path to the log file, by default ``None``.
-        verbose : bool, optional
-            Whether to print messages to the console, by default ``True``.
-        prefix : str | None, optional
-            A prefix to add to each logged message, by default ``None``.
-        """
+        # Initialize a FileLogger.
         self.path = path
         if path is not None:
             self.set_path(path)
@@ -61,28 +59,29 @@ class FileLogger:
             with open(self.path, "a", encoding="utf-8") as f:
                 f.write(f"{msg}\n")
 
-    def _print(self, msg: str, verbose=False):
-        """Print a message to the console.
+    def _print(self, msg: str, verbose: bool = False):
+        """
+        Print a message to the console.
 
         Parameters
         ----------
         msg : str
             The message to print.
-        verbose : bool, optional
+        verbose : bool
             Whether to print messages to the console, by default True.
         """
 
         if self.verbose or verbose:
             print(msg)
 
-    def info(self, msg: str, verbose=False) -> str:
+    def info(self, msg: str, verbose: bool = False) -> str:
         """Log an info message.
 
         Parameters
         ----------
         msg : str
             The message to log.
-        verbose : bool, optional
+        verbose : bool
             Whether to print messages to the console, by default ``False``.
 
         Returns
@@ -92,14 +91,14 @@ class FileLogger:
         """
         return self(msg, verbose)
 
-    def warn(self, msg: str, verbose=True) -> str:
+    def warn(self, msg: str, verbose: bool = True) -> str:
         """Log a warning message.
 
         Parameters
         ----------
         msg : str
             The message to log.
-        verbose : bool, optional
+        verbose : bool
             Whether to print messages to the console, by default ``True``.
 
         Returns
@@ -126,14 +125,14 @@ class FileLogger:
         msg = f"{FileLogger.FAIL}{msg}{FileLogger.ENDC}"
         return self(msg, True)
 
-    def __call__(self, msg: str, verbose=True) -> str:
+    def __call__(self, msg: str, verbose: bool = True) -> str:
         """Log a message.
 
         Parameters
         ----------
         msg : str
             The message to log.
-        verbose : bool, optional
+        verbose : bool
             Whether to print messages to the console, by default True.
 
 
@@ -153,7 +152,7 @@ class FileLogger:
 
         Parameters
         ----------
-        prefix : str | None, optional
+        prefix : str | None
             The prefix to add to each logged message, by default ``None``.
         """
         if prefix is not None:
@@ -202,7 +201,7 @@ class RemoteFileLogger(FileLogger):
             )
         )
 
-    def __call__(self, msg: str, verbose=True):
+    def __call__(self, msg: str, verbose: bool = True):
         if hasattr(self, "_file_logger"):
             msg = ray.get(self._file_logger.__call__.remote(msg, False))
             self._print(msg, verbose)

--- a/ablator/modules/loggers/file.py
+++ b/ablator/modules/loggers/file.py
@@ -193,7 +193,7 @@ class RemoteFileLogger(FileLogger):
             address, _ = ray.get_runtime_context().gcs_address.split(":")
         self._file_logger = (
             ray.remote(FileLogger)
-            .options(num_cpus=0.001, resources={f"node:{address}": 0.001})  # type: ignore
+            .options(num_cpus=0.001, resources={f"node:{address}": 0.001})
             .remote(
                 self.path,
                 self.verbose,

--- a/ablator/modules/loggers/main.py
+++ b/ablator/modules/loggers/main.py
@@ -2,6 +2,8 @@ import copy
 import json
 import time
 from pathlib import Path
+import typing as ty
+from typing import Any
 from typing import Optional, Union
 
 import numpy as np
@@ -55,16 +57,34 @@ class SummaryLogger:
         the trial directory.
     result_json_path : Path | None
         Path to the results JSON file.
+
+    Parameters
+    ----------
+    run_config : RunConfig
+        The run configuration.
+    experiment_dir : str | None | Path
+        Path to the trial directory, by default ``None``.
+    resume : bool
+        Whether to resume from an existing model directory, by default ``False``.
+    keep_n_checkpoints : int | None
+        Number of checkpoints to keep, by default ``None``.
+    verbose : bool
+        Whether to print messages to the console, by default ``True``.
+
+    Raises
+    ------
+    FileExistsError
+        If resume is set to ``False`` but the experiment directory already exists.
     """
 
-    SUMMARY_DIR_NAME = "dashboard"
-    RESULTS_JSON_NAME = "results.json"
-    LOG_FILE_NAME = "train.log"
-    CONFIG_FILE_NAME = "config.yaml"
-    BACKUP_CONFIG_FILE_NAME = "config_backup_{i}.yaml"
-    METADATA_JSON = "metadata.json"
-    CHKPT_DIR_NAMES = ["best", "recent"]
-    CHKPT_DIR_VALUES = ["best_checkpoints", "checkpoints"]
+    SUMMARY_DIR_NAME: str = "dashboard"
+    RESULTS_JSON_NAME: str = "results.json"
+    LOG_FILE_NAME: str = "train.log"
+    CONFIG_FILE_NAME: str = "config.yaml"
+    BACKUP_CONFIG_FILE_NAME: str = "config_backup_{i}.yaml"
+    METADATA_JSON: str = "metadata.json"
+    CHKPT_DIR_NAMES: list[str] = ["best", "recent"]
+    CHKPT_DIR_VALUES: list[str] = ["best_checkpoints", "checkpoints"]
     CHKPT_DIRS: dict[str, Path]
 
     def __init__(
@@ -75,23 +95,7 @@ class SummaryLogger:
         keep_n_checkpoints: int | None = None,
         verbose: bool = True,
     ):
-        """
-        Initialize a SummaryLogger.
-
-        Parameters
-        ----------
-        run_config : RunConfig
-            The run configuration.
-        experiment_dir : str | None | Path, optional
-            Path to the trial directory, by default ``None``.
-        resume : bool, optional
-            Whether to resume from an existing model directory, by default ``False``.
-        keep_n_checkpoints : int | None, optional
-            Number of checkpoints to keep, by default ``None``.
-        verbose : bool, optional
-            Whether to print messages to the console, by default ``True``.
-        """
-
+        # Initialize a SummaryLogger.
         run_config = copy.deepcopy(run_config)
         self.uid = run_config.uid
         self.keep_n_checkpoints: int = (
@@ -182,7 +186,7 @@ class SummaryLogger:
         ----------
         summary_dir : Path
             Path to the summary directory.
-        run_config : RunConfig | None, optional
+        run_config : RunConfig | None
             The run configuration, by default None.
 
         Returns
@@ -194,7 +198,7 @@ class SummaryLogger:
             return None
         return TensorboardLogger(summary_dir.joinpath("tensorboard"))
 
-    def _write_config(self, run_config: RunConfig):
+    def _write_config(self, run_config: RunConfig) -> None:
         """
         Write the run configuration to the model directory and to the dashboard.
 
@@ -202,6 +206,10 @@ class SummaryLogger:
         ----------
         run_config : RunConfig
             The run configuration.
+
+        Returns
+        -------
+        None
         """
         if self.experiment_dir is None:
             return
@@ -213,7 +221,8 @@ class SummaryLogger:
             self.dashboard.write_config(run_config)
 
     # pylint: disable=too-complex
-    def _add_metric(self, k, v, itr):
+    # flake8: noqa: C901
+    def _add_metric(self, k: str, v: ty.Any, itr: int) -> None:  # flake8: noqa
         """
         Add a metric to the dashboard.
 
@@ -221,10 +230,19 @@ class SummaryLogger:
         ----------
         k : str
             The metric name.
-        v : Any
+        v : ty.Any
             The metric value.
         itr : int
             The iteration.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If the datatype of the value ``v`` is unsupported.
         """
         if self.dashboard is None:
             return
@@ -290,7 +308,7 @@ class SummaryLogger:
         ----------
         metrics : Union[Metrics, dict]
             The metrics to update.
-        itr : Optional[int], optional
+        itr : Optional[int]
             The iteration, by default ``None``.
 
         Raises
@@ -328,8 +346,9 @@ class SummaryLogger:
         file_name: str,
         itr: int | None = None,
         is_best: bool = False,
-    ):
-        """Save a checkpoint and update the checkpoint iteration
+    ) -> None:
+        """
+        Save a checkpoint and update the checkpoint iteration
 
         Saves the model checkpoint in the appropriate directory based on the ``is_best`` parameter.
         If ``is_best==True``, the checkpoint is saved in the ``"best"`` directory, indicating the best
@@ -352,16 +371,15 @@ class SummaryLogger:
         file_name : str
             The file name.
 
-        itr : int | None, optional
+        itr : int | None
             The iteration, by default None. If not provided, the current iteration is incremented by 1.
 
-        is_best : bool, optional
+        is_best : bool
             Whether this is the best checkpoint, by default False.
 
-        Raises
-        ------
-        AssertionError
-            If the provided ``itr`` is not larger than the current iteration associated with the checkpoint.
+        Returns
+        -------
+        None
         """
         if self.experiment_dir is None:
             return
@@ -386,11 +404,11 @@ class SummaryLogger:
             file_path = dir_path.joinpath(f"{file_name}_{itr:010}.pt")
 
             assert not file_path.exists(), f"Checkpoint exists: {file_path}"
-            futils.save_checkpoint(save_dict, file_path)
+            futils.save_checkpoint(save_dict, file_path.as_posix())
             futils.clean_checkpoints(dir_path, self.keep_n_checkpoints)
             self._update_metadata()
 
-    def clean_checkpoints(self, keep_n_checkpoints: int):
+    def clean_checkpoints(self, keep_n_checkpoints: int) -> None:
         """
         Clean up checkpoints and keep only the specified number of checkpoints.
 
@@ -398,6 +416,10 @@ class SummaryLogger:
         ----------
         keep_n_checkpoints : int
             Number of checkpoints to keep.
+
+        Returns
+        -------
+        None
         """
         if self.experiment_dir is None:
             return
@@ -405,41 +427,32 @@ class SummaryLogger:
             dir_path = self.experiment_dir.joinpath(chkpt_dir)
             futils.clean_checkpoints(dir_path, keep_n_checkpoints)
 
-    def info(self, *args, **kwargs):
+    def info(self, *args: Any, **kwargs: Any):
         """
         Log an info to files and to console message using the logger.
 
         Parameters
         ----------
-        *args
-            Positional arguments passed to the logger's info method.
-        **kwargs
-            Keyword arguments passed to the logger's info method.
+        TODO{hiue}
         """
         self.logger.info(*args, **kwargs)
 
-    def warn(self, *args, **kwargs):
+    def warn(self, *args: Any, **kwargs: Any):
         """
         Log a warning message to files and to console using the logger.
 
         Parameters
         ----------
-        *args
-            Positional arguments passed to the logger's warn method.
-        **kwargs
-            Keyword arguments passed to the logger's warn method.
+        TODO{hiue}
         """
         self.logger.warn(*args, **kwargs)
 
-    def error(self, *args, **kwargs):
+    def error(self, *args: Any, **kwargs: Any):
         """
         Log an error message to files and to console using the logger.
 
         Parameters
         ----------
-        *args
-            Positional arguments passed to the logger's error method.
-        **kwargs
-            Keyword arguments passed to the logger's error method.
+        TODO{hiue}
         """
         self.logger.error(*args, **kwargs)

--- a/ablator/modules/loggers/main.py
+++ b/ablator/modules/loggers/main.py
@@ -198,7 +198,7 @@ class SummaryLogger:
             return None
         return TensorboardLogger(summary_dir.joinpath("tensorboard"))
 
-    def _write_config(self, run_config: RunConfig) -> None:
+    def _write_config(self, run_config: RunConfig):
         """
         Write the run configuration to the model directory and to the dashboard.
 
@@ -207,9 +207,6 @@ class SummaryLogger:
         run_config : RunConfig
             The run configuration.
 
-        Returns
-        -------
-        None
         """
         if self.experiment_dir is None:
             return
@@ -222,7 +219,7 @@ class SummaryLogger:
 
     # pylint: disable=too-complex
     # flake8: noqa: C901
-    def _add_metric(self, k: str, v: ty.Any, itr: int) -> None:  # flake8: noqa
+    def _add_metric(self, k: str, v: ty.Any, itr: int):
         """
         Add a metric to the dashboard.
 
@@ -234,10 +231,6 @@ class SummaryLogger:
             The metric value.
         itr : int
             The iteration.
-
-        Returns
-        -------
-        None
 
         Raises
         ------
@@ -346,7 +339,7 @@ class SummaryLogger:
         file_name: str,
         itr: int | None = None,
         is_best: bool = False,
-    ) -> None:
+    ):
         """
         Save a checkpoint and update the checkpoint iteration
 
@@ -377,9 +370,6 @@ class SummaryLogger:
         is_best : bool
             Whether this is the best checkpoint, by default False.
 
-        Returns
-        -------
-        None
         """
         if self.experiment_dir is None:
             return
@@ -408,7 +398,7 @@ class SummaryLogger:
             futils.clean_checkpoints(dir_path, self.keep_n_checkpoints)
             self._update_metadata()
 
-    def clean_checkpoints(self, keep_n_checkpoints: int) -> None:
+    def clean_checkpoints(self, keep_n_checkpoints: int):
         """
         Clean up checkpoints and keep only the specified number of checkpoints.
 
@@ -417,9 +407,6 @@ class SummaryLogger:
         keep_n_checkpoints : int
             Number of checkpoints to keep.
 
-        Returns
-        -------
-        None
         """
         if self.experiment_dir is None:
             return

--- a/ablator/modules/loggers/main.py
+++ b/ablator/modules/loggers/main.py
@@ -416,30 +416,41 @@ class SummaryLogger:
 
     def info(self, *args: Any, **kwargs: Any):
         """
-        Log an info to files and to console message using the logger.
+        Log an info to files and to console message using the logger. Here you can use
+        positional or keyword arguments. Possible parameters are shown in the Parameters section.
 
         Parameters
         ----------
-        TODO{hiue}
+        msg : str
+            The message to log.
+        verbose : bool
+            Whether to print messages to the console, by default ``False``.
+        
         """
         self.logger.info(*args, **kwargs)
 
     def warn(self, *args: Any, **kwargs: Any):
         """
-        Log a warning message to files and to console using the logger.
+        Log a warning message to files and to console using the logger. Here you can use
+        positional or keyword arguments. Possible parameters are shown in the Parameters section.
 
         Parameters
         ----------
-        TODO{hiue}
+        msg : str
+            The message to log.
+        verbose : bool
+            Whether to print messages to the console, by default ``True``.
         """
         self.logger.warn(*args, **kwargs)
 
     def error(self, *args: Any, **kwargs: Any):
         """
-        Log an error message to files and to console using the logger.
+        Log an error message to files and to console using the logger. Here you can use
+        positional or keyword arguments. Possible parameters are shown in the Parameters section.
 
         Parameters
         ----------
-        TODO{hiue}
+        msg : str
+            The message to log.
         """
         self.logger.error(*args, **kwargs)

--- a/ablator/modules/loggers/tensor.py
+++ b/ablator/modules/loggers/tensor.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Union
 import logging
+import typing as ty
 import numpy as np
 import pandas as pd
 from omegaconf import OmegaConf
@@ -10,12 +11,18 @@ from ablator.config.main import ConfigBase
 from ablator.config.utils import flatten_nested_dict
 from ablator.modules.loggers import LoggerBase
 
+
 logging.getLogger("tensorboardX").setLevel(logging.ERROR)
 
 
 class TensorboardLogger(LoggerBase):
     """
     A logger class for Tensorboard visualization.
+
+    Parameters
+    ----------
+    summary_dir : Union[str, Path]
+        The directory to store the Tensorboard summary files.
 
     Attributes
     ----------
@@ -26,18 +33,13 @@ class TensorboardLogger(LoggerBase):
     """
 
     def __init__(self, summary_dir: Union[str, Path]):
-        """
-        Initialize the TensorboardLogger with a summary directory.
-
-        Parameters
-        ----------
-        summary_dir : Union[str, Path]
-            The directory to store the Tensorboard summary files.
-        """
+        # Initialize the TensorboardLogger with a summary directory.
         self.summary_dir = Path(summary_dir).as_posix()
         self.backend_logger = SummaryWriter(log_dir=summary_dir)
 
-    def add_image(self, k, v, itr, dataformats="CHW"):
+    def add_image(
+        self, k: str, v: np.ndarray, itr: int, dataformats: ty.Optional[str] = "CHW"
+    ):
         """
         Add an image to the TensorBoard dashboard.
 
@@ -49,12 +51,12 @@ class TensorboardLogger(LoggerBase):
             The image data.
         itr : int
             The iteration number.
-        dataformats : str, optional
+        dataformats : ty.Optional[str]
             The format of the image data, by default ``"CHW"``.
         """
         self.backend_logger.add_image(k, v, itr, dataformats=dataformats)
 
-    def add_table(self, k, v: pd.DataFrame, itr):
+    def add_table(self, k: str, v: pd.DataFrame, itr: int):
         """
         Add a table to the TensorBoard dashboard.
 
@@ -69,7 +71,7 @@ class TensorboardLogger(LoggerBase):
         """
         self.backend_logger.add_text(k, v.to_markdown(), itr)
 
-    def add_text(self, k, v, itr):
+    def add_text(self, k: str, v: str, itr: int):
         """
         Add a text to the TensorBoard dashboard.
 
@@ -84,7 +86,7 @@ class TensorboardLogger(LoggerBase):
         """
         self.backend_logger.add_text(k, v, itr)
 
-    def add_scalars(self, k, v: dict[str, float | int], itr):
+    def add_scalars(self, k: str, v: dict[str, float | int], itr: int):
         """
         Add multiple scalars to the TensorBoard dashboard.
 
@@ -102,7 +104,7 @@ class TensorboardLogger(LoggerBase):
         # NOTE this is buggy:
         # self.backend_logger.add_scalars(k, v_dict, itr)
 
-    def add_scalar(self, k, v, itr):
+    def add_scalar(self, k: str, v: float | int, itr: int):
         """
         Add a scalar to the TensorBoard dashboard.
 

--- a/ablator/modules/metrics/main.py
+++ b/ablator/modules/metrics/main.py
@@ -286,7 +286,7 @@ class Metrics:
 
         Returns
         -------
-        metrics : dict
+        metrics : dict[str, float]
             A dictionary of metric values calculated from the predictions.
 
         Examples
@@ -321,7 +321,6 @@ class Metrics:
             self.reset(reset_ma=update)
         return metrics
 
-    # pylint: disable=missing-param-doc
     def append_batch(self, *args: ty.Any, **kwargs: ty.Any):
         """
         Appends a batch of predictions to a specific set.

--- a/ablator/modules/metrics/main.py
+++ b/ablator/modules/metrics/main.py
@@ -22,7 +22,7 @@ class Metrics:
     ----------
     *args : ty.Any
         This arguments is just for disabling passing by positional arguments.
-    batch_limit : int
+    batch_limit : int | None
         Maximum number of batches to keep for every category of data (specified by ``tags``), so only `batch_limit`
         number of latest batches is stored for each of the categories. Default is 30.
     memory_limit : int | None

--- a/ablator/modules/metrics/main.py
+++ b/ablator/modules/metrics/main.py
@@ -21,7 +21,7 @@ class Metrics:
     Parameters
     ----------
     *args : ty.Any
-        TODO{hiue}
+        This arguments is just for disabling passing by positional arguments.
     batch_limit : int
         Maximum number of batches to keep for every category of data (specified by ``tags``), so only `batch_limit`
         number of latest batches is stored for each of the categories. Default is 30.
@@ -328,7 +328,8 @@ class Metrics:
         Parameters
         ----------
         *args : ty.Any
-            TODO{hiue}
+            This arguments is just for disabling passing by positional arguments. This is because it is easy to mix up
+            the order of pred, labels and tags.
         **kwargs : ty.Any
             A dictionary of key-value pairs, where key is type of prediction (e.g predictions, labels),
             and value is a batch of prediction values. Note that the passed keys in ``**kwrags`` must match arguments in
@@ -338,10 +339,6 @@ class Metrics:
         ------
         ValueError
             If any positional arguments are passed.
-
-        Notes
-        -----
-        this is because it is easy to mix up the order of pred, labels and tags
 
         Examples
         --------

--- a/ablator/modules/metrics/main.py
+++ b/ablator/modules/metrics/main.py
@@ -18,11 +18,54 @@ class Metrics:
     We can access all the metrics from the ``Metrics`` object using its ``to_dict()`` method. Refer to
     `Prototyping Models <./notebooks/Prototyping-models.ipynb>`_ tutorial for more details.
 
+    Parameters
+    ----------
+    *args : ty.Any
+        TODO{hiue}
+    batch_limit : int
+        Maximum number of batches to keep for every category of data (specified by ``tags``), so only `batch_limit`
+        number of latest batches is stored for each of the categories. Default is 30.
+    memory_limit : int | None
+        Maximum memory (in bytes) of batches to keep for every category of data (specified by ``tags``). Every time
+        this limit is exceeded, ``batch_limit`` will be reduced by 1. Default is 1e8.
+    evaluation_functions : dict[str, Callable] | None
+        A dictionary of key-value pairs, keys are evaluation function names, values are
+        callable evaluation functions, e.g mean, sum. Note that arguments to this Callable
+        must match with names of prediction batches that the model returns. So if model prediction over
+        a batch looks like this: {"preds": <batch of predictions>, "labels": <batch of predicted labels>},
+        then callable's arguments should be ``preds`` and ``labels``, e.g ``evaluation_functions=
+        {"mean": lambda preds, labels: np.mean(preads) + np.mean(labels)}``. Default is None.
+    moving_average_limit : int | None
+        The maximum number of values allowed to store moving average metrics. Default is 3000.
+    static_aux_metrics : dict[str, ty.Any] | None
+        A dictionary of static metrics, those with their initial value that are updated manually,
+        such as learning rate, best loss, total steps, etc. Keys of this dictionary are static metric names,
+        while values is a proper initial value. Default is None.
+    moving_aux_metrics : Iterable[str] | None
+        A list of metrics, those we update with their moving average, such as loss. Default is None.
+
+    Examples
+    --------
+    Initialize an object of Metrics:
+
+    >>> from ablator.modules.metrics.main import Metrics
+    >>> train_metrics = Metrics(
+    ...     batch_limit=30,
+    ...     memory_limit=None,
+    ...     evaluation_functions={"mean": lambda x: np.mean(x)},
+    ...     moving_average_limit=100,
+    ...     static_aux_metrics={"lr": 1.0},
+    ...     moving_aux_metrics={"loss"},
+    ... )
+    >>> train_metrics.to_dict() # metrics are set to np.nan if it's not updated yet
+    {
+        "mean": np.nan, "loss": np.nan, "lr": 1.0
+    }
     """
 
     def __init__(
         self,
-        *args,
+        *args: ty.Any,
         batch_limit: int | None = 30,
         memory_limit: int | None = int(1e8),
         evaluation_functions: dict[str, Callable] | None = None,
@@ -32,52 +75,7 @@ class Metrics:
         # metrics for which we update with their moving average, i.e. loss
         moving_aux_metrics: Iterable[str] | None = None,
     ):
-        """
-        Initialize the train metrics settings
-
-        Parameters
-        ----------
-        batch_limit : int, optional
-            Maximum number of batches to keep for every category of data (specified by ``tags``), so only `batch_limit`
-            number of latest batches is stored for each of the categories. Default is 30.
-        memory_limit : int, optional
-            Maximum memory (in bytes) of batches to keep for every category of data (specified by ``tags``). Every time
-            this limit is exceeded, ``batch_limit`` will be reduced by 1. Default is 1e8.
-        evaluation_functions : dict[str, Callable], optional
-            A dictionary of key-value pairs, keys are evaluation function names, values are
-            callable evaluation functions, e.g mean, sum. Note that arguments to this Callable
-            must match with names of prediction batches that the model returns. So if model prediction over
-            a batch looks like this: {"preds": <batch of predictions>, "labels": <batch of predicted labels>},
-            then callable's arguments should be ``preds`` and ``labels``, e.g ``evaluation_functions=
-            {"mean": lambda preds, labels: np.mean(preads) + np.mean(labels)}``. Default is None.
-        moving_average_limit : int, optional
-            The maximum number of values allowed to store moving average metrics. Default is 3000.
-        static_aux_metrics : dict[str, ty.Any], optional
-            A dictionary of static metrics, those with their initial value that are updated manually,
-            such as learning rate, best loss, total steps, etc. Keys of this dictionary are static metric names,
-            while values is a proper initial value. Default is None.
-        moving_aux_metrics : Iterable[str], optional
-            A list of metrics, those we update with their moving average, such as loss. Default is None.
-
-        Examples
-        --------
-        Initialize an object of Metrics:
-
-        >>> from ablator.modules.metrics.main import Metrics
-        >>> train_metrics = Metrics(
-        ...     batch_limit=30,
-        ...     memory_limit=None,
-        ...     evaluation_functions={"mean": lambda x: np.mean(x)},
-        ...     moving_average_limit=100,
-        ...     static_aux_metrics={"lr": 1.0},
-        ...     moving_aux_metrics={"loss"},
-        ... )
-        >>> train_metrics.to_dict() # metrics are set to np.nan if it's not updated yet
-        {
-            "mean": np.nan, "loss": np.nan, "lr": 1.0
-        }
-        """
-
+        # Initialize the train metrics settings
         assert len(args) == 0, "Metrics takes no positional arguments."
 
         _static_aux_metrics = {} if static_aux_metrics is None else static_aux_metrics
@@ -273,7 +271,7 @@ class Metrics:
             _ma.reset()
             _ma.append(last)
 
-    def evaluate(self, reset=True, update=True):
+    def evaluate(self, reset: bool = True, update: bool = True) -> dict[str, float]:
         """
         Apply evaluation_functions to the set of predictions. Possibly update the
         moving averages (only those associated with evaluation functions, not moving auxiliary metrics) with
@@ -281,9 +279,9 @@ class Metrics:
 
         Parameters
         ----------
-        reset : bool, optional
+        reset : bool
             A flag that indicates whether to reset the predictions to empty after evaluation. Default is True.
-        update : bool, optional
+        update : bool
             A flag that indicates whether to update the moving averages after evaluation. Default is True.
 
         Returns
@@ -324,13 +322,15 @@ class Metrics:
         return metrics
 
     # pylint: disable=missing-param-doc
-    def append_batch(self, *args, **kwargs):
+    def append_batch(self, *args: ty.Any, **kwargs: ty.Any):
         """
         Appends a batch of predictions to a specific set.
 
         Parameters
         ----------
-        **kwargs : dict
+        *args : ty.Any
+            TODO{hiue}
+        **kwargs : ty.Any
             A dictionary of key-value pairs, where key is type of prediction (e.g predictions, labels),
             and value is a batch of prediction values. Note that the passed keys in ``**kwrags`` must match arguments in
             evaluation functions arguments in Callable in evaluation_functions when we initialize Metrics object.
@@ -365,7 +365,7 @@ class Metrics:
             raise ValueError("Metrics.append_batch takes no positional arguments.")
         self._preds.append(**kwargs)
 
-    def _init_ma(self, name) -> MovingAverage:
+    def _init_ma(self, name: str) -> MovingAverage:
         attr_name = f"__{name}_ma__"
         _ma = MovingAverage(
             batch_limit=self.__moving_average_limit__,
@@ -374,16 +374,21 @@ class Metrics:
         setattr(self, attr_name, _ma)
         return getattr(self, attr_name)
 
-    def _get_ma(self, name) -> MovingAverage:
+    def _get_ma(self, name: str) -> MovingAverage:
         attr_name = f"__{name}_ma__"
         preds = getattr(self, attr_name)
         return preds
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, ty.Any]:
         """
         Get all metrics, i.e moving auxiliary metrics, moving evaluation metrics, and static auxiliary metrics.
         Note that moving attributes will be an averaged value of all previous batches. Metrics are
-        set to np.nan if it's never updated before
+        set to np.nan if it's never updated before.
+
+        Returns
+        -------
+        dict[str, ty.Any]
+            Contains key-value pairs for metric's name and it's value.
 
         Examples
         --------

--- a/ablator/modules/metrics/stores.py
+++ b/ablator/modules/metrics/stores.py
@@ -289,7 +289,7 @@ class PredictionStore:
 
     Parameters
     ----------
-    batch_limit : int
+    batch_limit : int | None
         Maximum number of batches to keep for each array store corresponding to each category of prediction
         outputs (e.g preds, labels), so only ``batch_limit`` number of latest batches is stored per set of
         array store. Default is 30.

--- a/ablator/modules/metrics/stores.py
+++ b/ablator/modules/metrics/stores.py
@@ -574,7 +574,8 @@ class MovingAverage(ArrayStore):
     def __repr__(self) -> str:
         return f"{self.value:.2e}"
 
-    def append(self, val: ty.Union[np.ndarray, torch.Tensor, float, int]):  # noqa
+    # flake8: noqa: DOC502
+    def append(self, val: ty.Union[np.ndarray, torch.Tensor, float, int]):
         """
         Appends a batch of values, or a single value, constrained on the limits.
 

--- a/ablator/modules/metrics/stores.py
+++ b/ablator/modules/metrics/stores.py
@@ -30,7 +30,7 @@ def _parse_array_store_val(
     val: np.ndarray | int | float,
     store_type: None | type = None,
     shape: None | tuple[int, ...] = None,
-):
+) -> np.ndarray:
     if not isinstance(val, (np.ndarray, int, float)):
         raise RuntimeError(f"Invalid ArrayStore value type {type(val)}")
     np_val: np.ndarray
@@ -62,6 +62,22 @@ class ArrayStore(Sequence):
     """
     Base class for manipulations (storing, getting, resetting) of batches of values.
 
+    Parameters
+    ----------
+    batch_limit : int | None
+        The maximum number of batches of values to store for this single store.
+        If set to None, unlimited number of batches will be stored. Default is None.
+    memory_limit : int | None
+        The maximum memory allowed for the prediction store.
+        If set to None, unlimited number of batches will be stored. Default is None.
+
+    Examples
+    --------
+    >>> from ablator.modules.metrics.stores import ArrayStore
+    >>> train_metrics = ArrayStore(
+    ...     batch_limit=50,
+    ...     memory_limit=1000
+    ... )
     """
 
     def __init__(
@@ -70,26 +86,7 @@ class ArrayStore(Sequence):
         # 100 MB memory limit
         memory_limit: int | None = None,
     ):
-        """
-        Initialize the storage based on the memory / batch_limits provided.
-
-        Parameters
-        ----------
-        batch_limit : int, optional
-            The maximum number of batches of values to store for this single store.
-            If set to None, unlimited number of batches will be stored. Default is None.
-        memory_limit : int or None, optional
-            The maximum memory allowed for the prediction store.
-            If set to None, unlimited number of batches will be stored. Default is None.
-
-        Examples
-        --------
-        >>> from ablator.modules.metrics.stores import ArrayStore
-        >>> train_metrics = ArrayStore(
-        ...     batch_limit=50,
-        ...     memory_limit=1000
-        ... )
-        """
+        # Initialize the storage based on the memory / batch_limits provided.
         super().__init__()
         self._arr: list[np.ndarray] = []
         self.limit = int(batch_limit) if batch_limit is not None else None
@@ -108,17 +105,11 @@ class ArrayStore(Sequence):
 
         Parameters
         ----------
-        val : np.ndarray or float or int
+        val : np.ndarray | float | int
             The data, can be a batch of data, or a scalar.
-
-        Raises
-        ------
-        AssertionError:
-            If appended value is not numpy array, an integer, or a float number.
 
         Examples
         --------
-
         The following example shows a case where batch limit is exceeded
         (100 values/batches to be appended while only 10 is allowed)
 
@@ -232,6 +223,11 @@ class ArrayStore(Sequence):
         """
         Returns the stored values as a numpy array.
 
+        Returns
+        -------
+        np.ndarray
+            Returns the stored values.
+
         Examples
         --------
         >>> from ablator.modules.metrics.stores import ArrayStore
@@ -248,7 +244,7 @@ class ArrayStore(Sequence):
             return np.array([[]])
         return np.concatenate(self._arr)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._len
 
     def __getitem__(self, idx):
@@ -291,6 +287,39 @@ class PredictionStore:
     """
     A class for storing prediction scores. This allows for evaluating prediction results using evaluation functions
 
+    Parameters
+    ----------
+    batch_limit : int
+        Maximum number of batches to keep for each array store corresponding to each category of prediction
+        outputs (e.g preds, labels), so only ``batch_limit`` number of latest batches is stored per set of
+        array store. Default is 30.
+    memory_limit : int | None
+        Maximum memory (in bytes) of batches to keep for each array store corresponding to each category of
+        prediction outputs (e.g preds, labels). Default is 1e8.
+    moving_average_limit : int
+        The maximum number of values allowed to store moving average metrics. Default is 3000.
+    evaluation_functions : dict[str, Callable] | list[Callable] | None
+        A dictionary of key-value pairs, keys are evaluation function names, values are
+        callable evaluation functions, e.g mean, sum. Note that arguments to this Callable
+        must match with names of prediction batches that the model returns. So if model prediction over
+        a batch looks like this: ``{"preds": <batch of predictions>, "labels": <batch of predicted labels>}``,
+        then callable's arguments should be ``preds`` and ``labels``, e.g ``evaluation_functions=
+        {"mean": lambda preds, labels: np.mean(preads) + np.mean(labels)}``. Default is None.
+
+    Raises
+    ------
+    NotImplementedError
+        If the evaluation function is unrecognized.
+
+    Examples
+    --------
+    >>> from ablator.modules.metrics.stores import PredictionStore
+    >>> pred_store = PredictionStore(
+    ...     batch_limit=10,
+    ...     memory_limit=1000,
+    ...     moving_average_limit=1000,
+    ...     evaluation_functions={"mean": lambda x: np.mean(x)}
+    ... )
     """
 
     def __init__(
@@ -301,38 +330,7 @@ class PredictionStore:
         moving_average_limit: int = 3000,
         evaluation_functions: dict[str, Callable] | list[Callable] | None = None,
     ):
-        """
-        Initialize the storage settings.
-
-        Parameters
-        ----------
-        batch_limit : int, optional
-            Maximum number of batches to keep for each array store corresponding to each category of prediction
-            outputs (e.g preds, labels), so only ``batch_limit`` number of latest batches is stored per set of
-            array store. Default is 30.
-        memory_limit : int or None, optional
-            Maximum memory (in bytes) of batches to keep for each array store corresponding to each category of
-            prediction outputs (e.g preds, labels). Default is 1e8.
-        moving_average_limit : int, optional
-            The maximum number of values allowed to store moving average metrics. Default is 3000.
-        evaluation_functions : dict[str, Callable], optional
-            A dictionary of key-value pairs, keys are evaluation function names, values are
-            callable evaluation functions, e.g mean, sum. Note that arguments to this Callable
-            must match with names of prediction batches that the model returns. So if model prediction over
-            a batch looks like this: ``{"preds": <batch of predictions>, "labels": <batch of predicted labels>}``,
-            then callable's arguments should be ``preds`` and ``labels``, e.g ``evaluation_functions=
-            {"mean": lambda preds, labels: np.mean(preads) + np.mean(labels)}``. Default is None.
-
-        Examples
-        --------
-        >>> from ablator.modules.metrics.stores import PredictionStore
-        >>> pred_store = PredictionStore(
-        ...     batch_limit=10,
-        ...     memory_limit=1000,
-        ...     moving_average_limit=1000,
-        ...     evaluation_functions={"mean": lambda x: np.mean(x)}
-        ... )
-        """
+        # Initialize the storage settings.
         super().__init__()
         self.limit = batch_limit
         self.memory_limit = memory_limit
@@ -359,13 +357,13 @@ class PredictionStore:
         }
         self.__evaluation_functions__ = evaluation_functions_dict
 
-    def _init_arr(self, tag):
+    def _init_arr(self, tag: str) -> ArrayStore:
         attr_name = f"__{tag}_arr__"
         _arr = ArrayStore(batch_limit=self.limit, memory_limit=self.memory_limit)
         setattr(self, attr_name, _arr)
         return getattr(self, attr_name)
 
-    def _get_arr(self, tag) -> ArrayStore:
+    def _get_arr(self, tag: str) -> ArrayStore:
         attr_name = f"__{tag}_arr__"
         arr = getattr(self, attr_name)
         return arr
@@ -415,7 +413,6 @@ class PredictionStore:
         ...     evaluation_functions={"mean": lambda preds, labels: np.mean(preds) + np.mean(labels)}
         ... )
         >>> pred_store.append(preds=np.array([4,3,0]), labels=np.array([5,1,1]))
-
         """
         batch_keys = set(batches.keys())
         if len(batch_keys) == 0:
@@ -451,7 +448,7 @@ class PredictionStore:
 
         Returns
         -------
-        metrics : dict
+        dict[str, float]
             A dictionary of metric values calculated from different sets of predictions.
 
 
@@ -502,7 +499,7 @@ class PredictionStore:
         return metrics
 
     @property
-    def evaluation_function_arguments(self):
+    def evaluation_function_arguments(self) -> dict[str, list[str]]:
         if self.__evaluation_functions__ is None:
             return {}
         return {
@@ -568,16 +565,16 @@ class MovingAverage(ArrayStore):
     def __eq__(self, __o: object) -> bool:
         return float(self.value).__eq__(__o)
 
-    def __float__(self):
+    def __float__(self) -> float:
         return float(self.value)
 
-    def __format__(self, format_spec=".2e"):
+    def __format__(self, format_spec=".2e") -> str:
         return format(self.value, format_spec)
 
     def __repr__(self) -> str:
         return f"{self.value:.2e}"
 
-    def append(self, val: ty.Union[np.ndarray, torch.Tensor, float, int]):
+    def append(self, val: ty.Union[np.ndarray, torch.Tensor, float, int]):  # noqa
         """
         Appends a batch of values, or a single value, constrained on the limits.
 

--- a/ablator/modules/optimizer.py
+++ b/ablator/modules/optimizer.py
@@ -26,7 +26,7 @@ def get_optim_parameters(
 
     Returns
     -------
-    ty.Iterator[nn.Parameter]
+    abc.Iterator[nn.Parameter]
         The list of parameters that require to be optimized. It can be a list, tensor or dictionary. Please see
         Pytorch Optimizer documentation on the specific format.
 
@@ -128,8 +128,8 @@ class OptimizerConfig(ConfigBase):
         effects on the model performance. However, ``OptimizerConfig`` only configures one single
         optimizer for the experiment. But you can run experiments on different optimizers by creating
         a custom config class and add an extra method called ``make_optimizer``. Go to the tutorial on
-        `Search space for different types of optimizers and scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_
-        for more details.
+        `Search space for different types of optimizers and
+        scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_ for more details.
 
     """
 

--- a/ablator/modules/optimizer.py
+++ b/ablator/modules/optimizer.py
@@ -97,6 +97,16 @@ class OptimizerConfig(ConfigBase):
     arguments : OptimizerArgs
         Arguments for the optimizer, specific to a certain type of optimizer.
 
+    Parameters
+    ----------
+    name : str
+        Name of the optimizer, this can be any in ``['adamw', 'adam', 'sgd']``.
+    arguments : dict[str, ty.Any]
+        Arguments for the optimizer, specific to a certain type of optimizer. A common argument
+        can be learning rate, e.g ``{'lr': 0.5}``. If ``name`` is ``"adamw"``, can add ``eps`` to ``arguments``,
+        e.g ``{'lr': 0.5, 'eps': 0.001}``.
+
+
     Examples
     --------
     The following example shows how to create an optimizer config for SGD optimizer and use it in
@@ -126,28 +136,8 @@ class OptimizerConfig(ConfigBase):
     name: str
     arguments: OptimizerArgs
 
-    def __init__(self, name, arguments: dict[str, ty.Any]):
-        """
-        Initializes the optimizer configuration. Add any provided settings to the optimizer.
-
-        Parameters
-        ----------
-        name : str
-            Name of the optimizer, this can be any in ``['adamw', 'adam', 'sgd']``.
-        arguments : dict[str, ty.Any]
-            Arguments for the optimizer, specific to a certain type of optimizer. A common argument
-            can be learning rate, e.g ``{'lr': 0.5}``. If ``name`` is ``"adamw"``, can add ``eps`` to ``arguments``,
-            e.g ``{'lr': 0.5, 'eps': 0.001}``.
-
-        Examples
-        --------
-
-        In the following example, ``optim_config`` will initialize property ``arguments`` of type ``SGDConfig``,
-        setting ``lr=0.5`` as its property. We also have access to ``init_optimizer()`` method of the property,
-        which initalizes an SGD optimizer. This method is actually called in ``make_optimizer()``
-
-        >>> optim_config = OptimizerConfig("sgd", {"lr": 0.5})
-        """
+    def __init__(self, name: str, arguments: dict[str, ty.Any]):
+        # Initializes the optimizer configuration. Add any provided settings to the optimizer.
         argument_cls = OPTIMIZER_CONFIG_MAP[name]
         _arguments = argument_cls(**arguments)
         super().__init__(name=name, arguments=_arguments)
@@ -158,12 +148,12 @@ class OptimizerConfig(ConfigBase):
 
         Parameters
         ----------
-        model : torch.nn.Module
+        model : nn.Module
             The model to optimize.
 
         Returns
         -------
-        optimizer : torch.optim.Optimizer
+        optimizer : Optimizer
             The created optimizer.
 
         Examples
@@ -215,19 +205,19 @@ class SGDConfig(OptimizerArgs):
     weight_decay: float = 0.0
     momentum: float = 0.0
 
-    def init_optimizer(self, model: nn.Module):
+    def init_optimizer(self, model: nn.Module) -> SGD:
         """
         Creates and returns an SGD optimizer that optimizes the model's parameters. These parameters
         will be processed via ``get_optim_parameters`` before used to initalized the optimizer.
 
         Parameters
         ----------
-        model : torch.nn.Module
+        model : nn.Module
             The model that has parameters that the optimizer will optimize.
 
         Returns
         -------
-        optimizer : torch.optim.SGD
+        optimizer : SGD
             The created SGD optimizer.
 
         Examples
@@ -284,19 +274,19 @@ class AdamWConfig(OptimizerArgs):
     eps: float = 1e-8
     weight_decay: float = 0.01
 
-    def init_optimizer(self, model: nn.Module):
+    def init_optimizer(self, model: nn.Module) -> AdamW:
         """
         Creates and returns an ``AdamW`` optimizer that optimizes the model's parameters. These parameters
         will be processed via ``get_optim_parameters`` before used to initalized the optimizer.
 
         Parameters
         ----------
-        model : torch.nn.Module
+        model : nn.Module
             The model that has parameters that the optimizer will optimize.
 
         Returns
         -------
-        Optimizer
+        AdamW
             An instance of the ``AdamW`` optimizer.
 
         Examples
@@ -348,19 +338,19 @@ class AdamConfig(OptimizerArgs):
     betas: Tuple[float, float] = (0.9, 0.999)
     weight_decay: float = 0.0
 
-    def init_optimizer(self, model: nn.Module):
+    def init_optimizer(self, model: nn.Module) -> Adam:
         """
         Creates and returns an ``Adam`` optimizer that optimizes the model's parameters. These parameters
         will be processed via ``get_optim_parameters`` before used to initalized the optimizer.
 
         Parameters
         ----------
-        model : torch.nn.Module
+        model : nn.Module
             The model that has parameters that the optimizer will optimize.
 
         Returns
         -------
-        Optimizer
+        Adam
             An instance of the ``Adam`` optimizer.
 
         Examples

--- a/ablator/modules/scheduler.py
+++ b/ablator/modules/scheduler.py
@@ -42,7 +42,7 @@ class SchedulerConfig(ConfigBase):
     A class that defines a configuration for a learning rate scheduler. This scheduler config
     will be provided to ``TrainConfig`` (optional) as part of the training setting of the experiment.
 
-    Attributes
+    Arguments
     ----------
     name : str
         The name of the scheduler.
@@ -77,7 +77,8 @@ class SchedulerConfig(ConfigBase):
         effects on the model performance. However, ``SchedulerConfig`` only configures one single
         scheduler for the experiment. But you can run experiments on different schedulers by creating
         a custom config class and add an extra method called ``make_scheduler``. Go to this tutorial on
-        `Search space for different types of optimizers and scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_
+        `Search space for different types of
+        optimizers and scheduler <./notebooks/Searchspace-for-diff-optimizers.ipynb>`_
         for more details.
     """
 

--- a/ablator/modules/scheduler.py
+++ b/ablator/modules/scheduler.py
@@ -49,6 +49,13 @@ class SchedulerConfig(ConfigBase):
     arguments : SchedulerArgs
         The arguments needed to initialize the scheduler.
 
+    Parameters
+    ----------
+    name : str
+        The name of the scheduler, this can be any in ``['None', 'step', 'cycle', 'plateau']``.
+    arguments : dict[str, ty.Any]
+        The arguments for the scheduler, specific to a certain type of scheduler.
+    
     Examples
     --------
     The following example shows how to create a scheduler config and use it in

--- a/ablator/modules/scheduler.py
+++ b/ablator/modules/scheduler.py
@@ -42,7 +42,7 @@ class SchedulerConfig(ConfigBase):
     A class that defines a configuration for a learning rate scheduler. This scheduler config
     will be provided to ``TrainConfig`` (optional) as part of the training setting of the experiment.
 
-    Arguments
+    Attributes
     ----------
     name : str
         The name of the scheduler.
@@ -55,7 +55,7 @@ class SchedulerConfig(ConfigBase):
         The name of the scheduler, this can be any in ``['None', 'step', 'cycle', 'plateau']``.
     arguments : dict[str, ty.Any]
         The arguments for the scheduler, specific to a certain type of scheduler.
-    
+
     Examples
     --------
     The following example shows how to create a scheduler config and use it in

--- a/ablator/modules/storage/remote.py
+++ b/ablator/modules/storage/remote.py
@@ -2,6 +2,8 @@
 File is obsolete to be replaced with rclone. TODO
 """
 # pylint: skip-file
+# flake8: noqa
+
 import os
 import signal
 import subprocess

--- a/ablator/mp/gpu_manager.py
+++ b/ablator/mp/gpu_manager.py
@@ -93,10 +93,11 @@ def wait_get_gpu(
     """
     timeouts = 0
     # TODO the node_ip needs to be specified when requesting a GPU
+    least_used_gpu: int
     while timeouts < max_timeouts:
         if (
             least_used_gpu := ray.get(
-                manager.request_gpu.remote(  # type: ignore
+                manager.request_gpu.remote( # type: ignore[attr-defined]
                     expected_util_mb, process_name
                 )
             )
@@ -104,7 +105,7 @@ def wait_get_gpu(
             time.sleep(1)
             timeouts += 1
             continue
-        return least_used_gpu  # type: ignore
+        return least_used_gpu
     raise GPUError("No available GPU.")
 
 
@@ -122,7 +123,7 @@ def unlock_gpu(manager: "GPUManager", gpu: int):
         the id of the GPU that will unlock.
 
     """
-    ray.get(manager.unlock.remote(gpu))  # type: ignore
+    ray.get(manager.unlock.remote(gpu)) # type: ignore[attr-defined]
 
 
 @ray.remote(num_cpus=0.001, num_gpus=0.001)

--- a/ablator/mp/gpu_manager.py
+++ b/ablator/mp/gpu_manager.py
@@ -24,7 +24,7 @@ class GPU:
     ----------
     num : int
         the GPU id number
-    free_mem : int | None
+    free_mem : int
         the free memory for the given GPU in MB
     is_locked : bool
         whether the GPU is currently pending memory allotment.
@@ -80,6 +80,7 @@ def wait_get_gpu(
         the name of the process to use to identify memory utilization, by default ``None``
     max_timeouts : int
         the seconds of timeouts after which to throw an error, by default 60
+
     Returns
     -------
     int
@@ -170,9 +171,9 @@ class GPUManager:
 
         Parameters
         ----------
-        expected_util_mb : int
+        expected_util_mb : int | None
             the expected utilization of the cuda process.
-        process_name : str
+        process_name : str | None
             the name of the process requesting the GPU resources, by default ``None``
 
         Returns

--- a/ablator/mp/node_manager.py
+++ b/ablator/mp/node_manager.py
@@ -86,7 +86,7 @@ class NodeManager:
             node_ip = node.node_ip
             node_alive = node.state.lower() == "alive"
             if node_alive and node_ip not in self.nodes:
-                future = update_node.options(  # type: ignore
+                future = update_node.options(
                     resources={f"node:{node_ip}": 0.001}
                 ).remote(node_ip, self.public_key)
                 try:

--- a/ablator/mp/train_remote.py
+++ b/ablator/mp/train_remote.py
@@ -111,47 +111,47 @@ def train_main_remote(
         The ModelWrapper that is used to train a model.
     run_config : ParallelConfig
         Runtime configuration for this trial.
-    mp_logger : FileLogger
+    mp_logger : RemoteFileLogger
         The file logger that's used to log training progress.
-    gpu_manager : GPUManager | None
+    gpu_manager : ty.Union[GPUManager, None]
         The gpu manager that is used to inform when the training progress starts
     gpu_id : int | None
         The gpu id to which to assign resources on the current remote.
     uid : int
         the trial unique identifier.
-    fault_tollerant : bool, optional, default=True
-        Whether to tollerate crashes, aka to cease execution when the ray job crashes.
-    crash_exceptions_types : list[type], None, optional, default=None
-        Types of exceptions that are considered as crashes.
-    resume : bool, default=False
-        Whether to resume training the model from existing checkpoints and existing experiment state.
-    clean_reset : bool, default=False
-        Whether to remove model directory when ``CheckpointNotFoundError`` is raised.
-    progress_bar : RemoteProgressBar, optional
+    fault_tollerant : bool
+        Whether to tollerate crashes, aka to cease execution when the ray job crashes. By default ``True``
+    crash_exceptions_types : list[type] | None
+        Types of exceptions that are considered as crashes. By default ``None``
+    resume : bool
+        Whether to resume training the model from existing checkpoints and existing experiment state. By default ``False``
+    clean_reset : bool
+        Whether to remove model directory when ``CheckpointNotFoundError`` is raised. By default ``False``
+    progress_bar : ty.Optional[RemoteProgressBar]
         Optionally, we can use a remote progress bar to update the results of the trial.
     data_lock : Lock, optional
         Use a Lock for when building the dataloader to ensure that it does not concurrently
         download data for several processes
     Returns
     -------
-    int
-        The trial uid corresponding to the results.
-    dict[str, float], None
-        If exception raised (Except for LossDivergedError and TrainPlateauError),
-        this will be ``None`` object. Otherwise, this will be a dictionary of metrics.
-    TrialState
-        A TrialState object indicating the state of the trial job
+    tuple[int, dict[str, float] | None, TrialState]
+        int
+            The trial uid corresponding to the results.
+        dict[str, float], None
+            If exception raised (Except for LossDivergedError and TrainPlateauError),
+            this will be ``None`` object. Otherwise, this will be a dictionary of metrics.
+        TrialState
+            A TrialState object indicating the state of the trial job
 
-        - If ``LossDivergedError`` or ``TrainPlateauError`` is raised while training,
-          returned state will be ``TrialState.PRUNED_POOR_PERFORMANCE``
+            - If ``LossDivergedError`` or ``TrainPlateauError`` is raised while training,
+            returned state will be ``TrialState.PRUNED_POOR_PERFORMANCE``
 
-        - If ``RuntimeError`` (with message ``'CUDA out of memory'``),
-          or ``CheckpointNotFoundError`` (with ``clean_reset=True``) is raised while training,
-          returned state will be ``TrialState.FAIL_RECOVERABLE``
+            - If ``RuntimeError`` (with message ``'CUDA out of memory'``),
+            or ``CheckpointNotFoundError`` (with ``clean_reset=True``) is raised while training,
+            returned state will be ``TrialState.FAIL_RECOVERABLE``
 
-        - If other types of error or ``CheckpointNotFoundError`` (with ``clean_reset=False``) is raised,
-          returned state will be ``TrialState.FAIL``
-
+            - If other types of error or ``CheckpointNotFoundError`` (with ``clean_reset=False``) is raised,
+            returned state will be ``TrialState.FAIL``
     """
     if gpu_id is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)

--- a/ablator/mp/train_remote.py
+++ b/ablator/mp/train_remote.py
@@ -26,7 +26,7 @@ def _apply_unlock_hook(
 ) -> ModelWrapper:
     if gpu_manager is None:
         return model
-    model._is_locked = True  # type: ignore
+    model._is_locked = True
 
     def lock_on_unlocked():
         if model._is_locked:
@@ -45,7 +45,7 @@ def _apply_unlock_hook(
     _hook_fn = hook_function(
         model.__getattribute__("train_step", True), lock_on_unlocked
     )
-    setattr(model, "train_step", _hook_fn)  # type: ignore
+    setattr(model, "train_step", _hook_fn)
     return model
 
 

--- a/ablator/mp/train_remote.py
+++ b/ablator/mp/train_remote.py
@@ -124,12 +124,13 @@ def train_main_remote(
     crash_exceptions_types : list[type] | None
         Types of exceptions that are considered as crashes. By default ``None``
     resume : bool
-        Whether to resume training the model from existing checkpoints and existing experiment state. By default ``False``
+        Whether to resume training the model from existing checkpoints
+        and existing experiment state. By default ``False``
     clean_reset : bool
         Whether to remove model directory when ``CheckpointNotFoundError`` is raised. By default ``False``
     progress_bar : ty.Optional[RemoteProgressBar]
         Optionally, we can use a remote progress bar to update the results of the trial.
-    data_lock : Lock, optional
+    data_lock : ty.Optional[butils.Lock], optional
         Use a Lock for when building the dataloader to ensure that it does not concurrently
         download data for several processes
     Returns

--- a/ablator/mp/utils.py
+++ b/ablator/mp/utils.py
@@ -95,11 +95,11 @@ def _sorted_nodes_by_util(
     ----------
     resources : dict[str, Resource]
         a dictionary of the nodes with their available resources
-    gpu_util_requirement : int | None, optional
+    gpu_util_requirement : int | None
         the gpu requirement for the task, by default None
-    memory_perc_limit : int, optional
+    memory_perc_limit : int
         the percentage upper limit to memory utilization, by default 80
-    cpu_util_perc_limit : int, optional
+    cpu_util_perc_limit : int
         the percentage upper limit to cpu utilization, by default 80
 
     Returns

--- a/ablator/utils/_nvml.py
+++ b/ablator/utils/_nvml.py
@@ -51,7 +51,7 @@ def _handleError(err: "nvml.NVMLError") -> str:
         return "N/A"
     return str(err)
 
-
+# flake8: noqa: E722
 def getProcessName(pid):
     try:
         if os.name == "nt" or "microsoft-standard" in uname().release:

--- a/ablator/utils/base.py
+++ b/ablator/utils/base.py
@@ -44,7 +44,7 @@ class _Lock:
 class Lock:
     def __init__(self, timeout: float | None = None) -> None:
         # pylint: disable=no-member
-        self.lock = _Lock.remote()  # type: ignore
+        self.lock = _Lock.remote() # type: ignore[attr-defined]
 
         self.timeout = timeout
 

--- a/ablator/utils/base.py
+++ b/ablator/utils/base.py
@@ -77,7 +77,7 @@ class Lock:
         ray.get(self.lock.release.remote())
 
 
-def iter_to_numpy(iterable):
+def iter_to_numpy(iterable: Iterable) -> ty.Any:
     """
     Convert elements of the input iterable to NumPy arrays if they are torch.Tensor objects.
 
@@ -88,7 +88,7 @@ def iter_to_numpy(iterable):
 
     Returns
     -------
-    any
+    ty.Any
         The iterable with torch.Tensor elements replaced with their NumPy array equivalents.
     """
     return apply_lambda_to_iter(
@@ -98,16 +98,16 @@ def iter_to_numpy(iterable):
 
 
 def iter_to_device(
-    data_dict, device
+    data_dict: Iterable, device: str
 ) -> ty.Union[Sequence[torch.Tensor], dict[str, torch.Tensor]]:
     """
     Moving torch.Tensor elements to the specified device.
 
     Parameters
     ----------
-    data_dict : dict or list
+    data_dict : Iterable
         The input dictionary or list containing torch.Tensor elements.
-    device : torch.device | str
+    device : str
         The target device for the tensors.
 
     Returns
@@ -120,7 +120,7 @@ def iter_to_device(
     )
 
 
-def apply_lambda_to_iter(iterable, fn: Callable):
+def apply_lambda_to_iter(iterable: Iterable, fn: Callable) -> ty.Any:
     """
     Applies a given function ``fn`` to each element of an iterable data structure.
 
@@ -137,7 +137,7 @@ def apply_lambda_to_iter(iterable, fn: Callable):
 
     Returns
     -------
-    any
+    ty.Any
         The resulting data structure after applying ``fn`` to each element of the input ``iterable``.
         The type of the returned object matches the type of the input ``iterable``.
     """
@@ -152,7 +152,7 @@ def apply_lambda_to_iter(iterable, fn: Callable):
     return fn(iterable)
 
 
-def set_seed(seed: int):
+def set_seed(seed: int) -> int:
     """
     Set the random seed.
 
@@ -174,13 +174,13 @@ def set_seed(seed: int):
     return seed
 
 
-def get_lr(optimizer):
+def get_lr(optimizer: torch.optim.Optimizer | dict) -> float:
     """
     Get the learning rate from an optimizer.
 
     Parameters
     ----------
-    optimizer : torch.optim.Optimizer or dict
+    optimizer : torch.optim.Optimizer | dict
         The optimizer.
 
     Returns
@@ -230,7 +230,7 @@ def get_latest_chkpts(checkpoint_dir: Path) -> list[Path]:
     return sorted(list(checkpoint_dir.glob("*.pt")))[::-1]
 
 
-def parse_device(device: ty.Union[str, list[str]]):
+def parse_device(device: ty.Union[str, list[str], int]) -> ty.Any:
     """
     Parse a device string, an integer, or a list of device strings or integers.
 
@@ -241,7 +241,7 @@ def parse_device(device: ty.Union[str, list[str]]):
 
     Returns
     -------
-    any
+    ty.Any
         The parsed device string, integer, or list of device strings or integers.
 
     Raises
@@ -361,15 +361,28 @@ def num_format(
 
     Parameters
     ----------
-    value : int | float
+    value : str | int | float | np.integer | np.floating
         the value to format
-    width : int, optional
-        the width of the decimal places, by default 5
+    width : int
+        the width of the decimal places, by default 8
 
     Returns
     -------
     str
         The formatted string representation of the `value`
+
+    Examples
+    --------
+    >>> num_format(123456, width=8)
+    123456
+    >>> num_format(123456789, width=8)
+    1.23e+08
+    >>> num_format(1234.5678, width=8)
+    1.23e+03
+    >>> num_format(0.000012345, width=8)
+    1.23e-05
+    >>> num_format(np.float64(12345678.12345678), width=8)
+    1.23e+07
     """
     assert width >= 8
     if isinstance(value, (int, np.integer)):

--- a/ablator/utils/file.py
+++ b/ablator/utils/file.py
@@ -25,7 +25,7 @@ def make_sub_dirs(parent: str | Path, *dir_names: str) -> list[Path]:
     list[Path]
         A list of created subdirectory paths.
 
-     Examples
+    Examples
     --------
     >>> parent_directory = "C:/example_parent_directory"
     >>> subdirectory_names = ["subdir1", "subdir2", "subdir3"]

--- a/ablator/utils/file.py
+++ b/ablator/utils/file.py
@@ -9,7 +9,7 @@ import pandas as pd
 import torch
 
 
-def make_sub_dirs(parent: str | Path, *dir_names) -> list[Path]:
+def make_sub_dirs(parent: str | Path, *dir_names: str) -> list[Path]:
     """
     Create subdirectories under the given parent directory.
 
@@ -24,6 +24,16 @@ def make_sub_dirs(parent: str | Path, *dir_names) -> list[Path]:
     -------
     list[Path]
         A list of created subdirectory paths.
+
+     Examples
+    --------
+    >>> parent_directory = "C:/example_parent_directory"
+    >>> subdirectory_names = ["subdir1", "subdir2", "subdir3"]
+    >>> created_subdirectories = make_sub_dirs(parent_directory, *subdirectory_names)
+    >>> created_subdirectories
+    [Path('C:/example_parent_directory/subdir1'),
+     Path('C:/example_parent_directory/subdir2'),
+     Path('C:/example_parent_directory/subdir3')]
     """
     dirs = []
     for dir_name in dir_names:
@@ -33,15 +43,15 @@ def make_sub_dirs(parent: str | Path, *dir_names) -> list[Path]:
     return dirs
 
 
-def save_checkpoint(state, filename="checkpoint.pt"):
+def save_checkpoint(state: object, filename: str = "checkpoint.pt"):
     """
     Save a checkpoint of the given state.
 
     Parameters
     ----------
-    state : dict
+    state : object
         Model State dictionary to save.
-    filename : str, optional
+    filename : str
         The name of the checkpoint file, by default "checkpoint.pt".
     """
     torch.save(state, filename)
@@ -67,8 +77,9 @@ def clean_checkpoints(checkpoint_folder: Path, n_checkpoints: int):
             Path(_chkpt).unlink(missing_ok=True)
 
 
-def default_val_parser(val):
-    """Converts the input value to a JSON compatible format.
+def default_val_parser(val: ty.Any) -> ty.Any:
+    """
+    Converts the input value to a JSON compatible format.
 
     Parameters
     ----------
@@ -90,7 +101,7 @@ def default_val_parser(val):
     return str(val)
 
 
-def json_to_dict(json_):
+def json_to_dict(json_: str) -> dict:
     """
     Convert a JSON string into a dictionary.
 
@@ -109,7 +120,7 @@ def json_to_dict(json_):
     return dict_
 
 
-def dict_to_json(dict_):
+def dict_to_json(dict_: dict) -> str:
     """
     Convert a dictionary into a JSON string.
 
@@ -129,7 +140,7 @@ def dict_to_json(dict_):
     return _json
 
 
-def nested_set(dict_, keys: list[str], value: ty.Any):
+def nested_set(dict_: dict, keys: list[str], value: ty.Any) -> dict:
     """
     Set a value in a nested dictionary.
 

--- a/ablator/utils/file.py
+++ b/ablator/utils/file.py
@@ -35,7 +35,7 @@ def make_sub_dirs(parent: str | Path, *dir_names: str) -> list[Path]:
      Path('C:/example_parent_directory/subdir2'),
      Path('C:/example_parent_directory/subdir3')]
     """
-    dirs = []
+    dirs: list[Path] = []
     for dir_name in dir_names:
         dir_path = Path(parent).joinpath(dir_name)
         dir_path.mkdir(parents=True, exist_ok=True)

--- a/ablator/utils/progress_bar.py
+++ b/ablator/utils/progress_bar.py
@@ -241,7 +241,7 @@ class RemoteDisplay(Display):
         if time.time() - self._prev_update_time > self.update_interval or force:
             self._prev_update_time = time.time()
             self.print_texts(
-                ray.get(self.remote_progress_bar.make_print_texts.remote())  # type: ignore
+                ray.get(self.remote_progress_bar.make_print_texts.remote()) # type: ignore[assignment, attr-defined]
             )
 
 

--- a/ablator/utils/progress_bar.py
+++ b/ablator/utils/progress_bar.py
@@ -67,7 +67,7 @@ class Display:
     """
     Class for handling display for terminal and notebook.
 
-    Arguments
+    Attributes
     ---------
     _curses : curses
         curses object
@@ -241,7 +241,7 @@ class RemoteDisplay(Display):
         if time.time() - self._prev_update_time > self.update_interval or force:
             self._prev_update_time = time.time()
             self.print_texts(
-                ray.get(self.remote_progress_bar.make_print_texts.remote())
+                ray.get(self.remote_progress_bar.make_print_texts.remote())  # type: ignore
             )
 
 

--- a/examples/resnet.py
+++ b/examples/resnet.py
@@ -98,11 +98,11 @@ class MyModelWrapper(ModelWrapper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def make_dataloader_train(self, run_config: ResRunConfig):  # type: ignore
+    def make_dataloader_train(self, run_config: ResRunConfig):
         # return load_cifar10(run_config, flag="val")
         return load_cifar10(run_config, flag="train")
 
-    def make_dataloader_val(self, run_config: ResRunConfig):  # type: ignore
+    def make_dataloader_val(self, run_config: ResRunConfig):
         return load_cifar10(run_config, flag="val")
 
     def evaluation_functions(self) -> Dict[str, Callable]:

--- a/extra/mypy_plugin.py
+++ b/extra/mypy_plugin.py
@@ -1,4 +1,4 @@
-from mypy.plugin import *
+from mypy.plugin import Callable, AnalyzeTypeContext, Type, Plugin
 from mypy.types import TupleType, UnionType, NoneType, AnyType, TypeOfAny
 from mypy import errorcodes
 from mypy.typevars import fill_typevars

--- a/tests/main/test_trainer.py
+++ b/tests/main/test_trainer.py
@@ -114,6 +114,20 @@ class TestWrapper2(ModelWrapper):
         return dl
 
 
+def my_accuracy(preds):
+    return float(np.mean(preds))
+
+
+class TestWrapperCustomEval(TestWrapper):
+    def evaluation_functions(self):
+        return {"mean": my_accuracy}
+
+
+class TestWrapperCustomEvalUnderscore(TestWrapper):
+    def evaluation_functions(self):
+        return {"mean_score": my_accuracy}
+
+
 def test_proto(tmp_path: Path, config, working_dir):
     wrapper = TestWrapper(MyCustomModel)
 
@@ -301,6 +315,23 @@ def test_git_diffs(
     msg = ablator._get_diffs(repo_path)
     diffs = msg.split("\n")
     assert all(diffs[-(i + 1)] == f"-{99-i}" for i in range(50))
+
+
+def test_proto_custom_eval(tmp_path: Path, config):
+    wrapper = TestWrapperCustomEval(MyCustomModel)
+    config.experiment_dir = tmp_path.joinpath(f"{random.random()}")
+    ablator = ProtoTrainer(wrapper=wrapper, run_config=config)
+    train_metrics = ablator.launch(tmp_path)
+    eval_metrics = ablator.evaluate()
+    assert np.isclose(train_metrics["val_mean"], eval_metrics["val"]["mean"])
+    wrapper = TestWrapperCustomEvalUnderscore(MyCustomModel)
+    config.experiment_dir = tmp_path.joinpath(f"{random.random()}")
+    ablator = ProtoTrainer(wrapper=wrapper, run_config=config)
+    train_metrics = ablator.launch(tmp_path)
+    eval_metrics = ablator.evaluate()
+    assert np.isclose(
+        train_metrics["val_mean_score"], eval_metrics["val"]["mean_score"]
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These are the changes from: https://github.com/fostiropoulos/ablator/pull/112 

Combined and with several updates due to conflicts. @hieuchi911 can we please figure out whether the changes make sense? 

Also some of the `fixes` break pylint or are erroneous or uninformative.

e.g. is 
`ablator/modules/loggers/main.py:343:4: W9008: Redundant returns documentation (redundant-returns-doc)`

Or poorly documented *args, **kwargs. For example for Categorical Plots we should point to the parent class args, kwargs. There should be examples online. e.g. https://stackoverflow.com/questions/2025562/inherit-docstrings-in-python-class-inheritance